### PR TITLE
fix: graph.html への JSON 注入を XSS 安全にする (#11)

### DIFF
--- a/src/renderer/webp-generator.js
+++ b/src/renderer/webp-generator.js
@@ -148,12 +148,14 @@ async function renderScene(processedData, scene, theme, size) {
     const dimensions = getSizeDimensions(size);
     await page.setViewport(dimensions);
 
+    const safeData = JSON.stringify(processedData).replace(/</g, '\\u003c');
+    const safeTheme = JSON.stringify(theme).replace(/</g, '\\u003c');
     const injectedHTML = HTML_TEMPLATE.replace(
       '</head>',
       `<script>
-        window.ACTIVITY_DATA = ${JSON.stringify(processedData)};
+        window.ACTIVITY_DATA = ${safeData};
         window.RENDER_SCENE = ${scene};
-        window.RENDER_THEME = ${JSON.stringify(theme)};
+        window.RENDER_THEME = ${safeTheme};
       </script></head>`
     );
 


### PR DESCRIPTION
## 関連 Issue
closes #11

## 変更内容

`src/renderer/webp-generator.js` の `renderScene()` 内で `<script>window.ACTIVITY_DATA = ...</script>` の形で JSON を埋め込んでいたが、`JSON.stringify` は `</script>` をエスケープしないため、commit message に `</script>` を仕込まれると Puppeteer 内で任意 JS が走る可能性があった。

PR #10 で `embed.html` 側に施したのと同じく、`.replace(/</g, '\\u003c')` でユニコードエスケープを適用。

- `ACTIVITY_DATA` (commit message 等を含む) → エスケープ
- `RENDER_THEME` (allowlist 済みだが統一のため) → エスケープ
- `RENDER_SCENE` (内部 numeric) → エスケープ不要

## 動作確認

```js
const malicious = { message: 'foo</script><script>alert(1)</script>bar' };
JSON.stringify(malicious).replace(/</g, '\\u003c')
// => {"message":"foo</script><script>alert(1)</script>bar"}
```

`</script>` を含まず、JS パース後は元の文字列に復元される。