### PR TITLE
Phase 1: film-inspired palette system with source-aware accents (#3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ kira-activity/
 
 - `user` (必須)
 - `source` (`github` | `hatena`、default `github`)
-- `theme` (`deathnote`、default `deathnote`)
+- `theme` (`film` | `github` | `hatena` | `sepia` | `mono`、default `film`)
 - `size` (`small` | `medium` | `large`、default `medium`)
 - `view` (`kira` | `month` | `week` | `auto`、default `auto`)
 
@@ -83,6 +83,23 @@ kira-activity/
 | `week` | 3 | `renderScene3()` | 週次 2D 折れ線グラフ |
 
 scene 1（ランダムリスト）は補助演出。本番ループには含めない。
+
+## Palette アーキテクチャ
+
+配色は `src/renderer/palette.js` に集約された 5 トークン（background / ink / grid /
+accent / highlight）× 5 テーマで定義する。
+
+- `theme=film` のときだけ `source` に応じて accent が変わる（`github`→くすんだ緑、
+  `hatena`→くすんだ青）。background / ink / grid / highlight はフィルム配色のまま。
+- 他のテーマ（`github` / `hatena` / `sepia` / `mono`）はテーマ自身の配色を優先し、
+  source による accent 切り替えは行わない。
+- パレットはサーバ側で 1 回だけ resolve し、`/embed` には CSS 変数（`--kira-bg` ほか）
+  として、`/api/graph` には `window.RENDER_PALETTE` として注入される。
+- CSS 注入の安全性は `sanitizePalette()` が `^#[0-9a-fA-F]{6}$` を保証することで担保。
+  JS 注入は既存の `JSON.stringify(...).replace(/</g, '\\u003c')` パターン。
+
+Phase 1 では scene 1..4 内の最も目立つハードコード色（背景・軸・グリッド・線・
+ドット・3D エッジ）だけパレット化し、ツールチップ等の細部は Phase 2/3 の再設計で扱う。
 
 ## レンダリングフロー
 
@@ -166,7 +183,7 @@ Node.js より 2–3 倍高速（`bun src/server.js`）。
 
 - Three.js による可視化
 - 4 つの `renderScene{N}()` 関数
-- `window.ACTIVITY_DATA` / `window.RENDER_SCENE` / `window.RENDER_THEME` でデータ注入
+- `window.ACTIVITY_DATA` / `window.RENDER_SCENE` / `window.RENDER_THEME` / `window.RENDER_PALETTE` でデータ注入
 
 ### src/renderer/embed.html
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm start
 |---|---|---|---|
 | `user` | string | （必須） | ユーザー名 |
 | `source` | `github` / `hatena` | `github` | データソース |
-| `theme` | `deathnote` | `deathnote` | 配色テーマ |
+| `theme` | `film` / `github` / `hatena` / `sepia` / `mono` | `film` | 配色テーマ |
 | `size` | `small` / `medium` / `large` | `medium` | ビューポートサイズ |
 | `view` | `kira` / `month` / `week` / `auto` | `auto` | 表示モード |
 
@@ -60,12 +60,26 @@ npm start
 - `week` — 曜日別の週次 2D 折れ線グラフ（Phase 2 で 7 × 24 オーバーレイに置換予定）
 - `auto` — 上記を順に再生するアニメーション（`/api/graph` のデフォルト挙動）
 
+### テーマと source-aware accent
+
+- `film` — クリーム背景 + 濃い灰/茶インク。デスノート分析モニタの温度感
+- `github` — GitHub 草ダーク配色（黒背景 + 緑）
+- `hatena` — はてな寄り（白背景 + 青）
+- `sepia` — 暖色のセピア
+- `mono` — 無彩色のニュートラル
+
+`theme=film` のときだけ `source` に応じてアクセント色が変わる: `source=github` で
+くすんだ緑、`source=hatena` でくすんだ青。背景・インク・グリッドはフィルム配色のまま
+維持される。他のテーマはアクセントを固定し、テーマ自身のアイデンティティを優先する。
+
 ## 使用例
 
 - `/embed?user=torvalds` — auto 再生する iframe
 - `/embed?user=torvalds&view=kira` — kira 固定の iframe
 - `/api/graph?user=torvalds` — auto をアニメ WebP として書き出し
-- `/api/graph?user=torvalds&view=week&theme=deathnote&size=large` — 単一ビューの WebP
+- `/api/graph?user=torvalds&view=week&theme=film&size=large` — 単一ビューの WebP
+- `/api/graph?user=torvalds&source=github&theme=film` — film 配色 + GitHub 緑のアクセント
+- `/api/graph?user=torvalds&source=hatena&theme=film` — film 配色 + はてな青のアクセント
 
 ## 技術スタック
 

--- a/docs/visual-direction.md
+++ b/docs/visual-direction.md
@@ -33,20 +33,22 @@
 
 API では色指定を `theme` の単語だけで済ませず、最終的には次のような層に分ける。
 
-> **Phase 0 status:** 現状の実装では `theme=deathnote` のみが有効。下記の
-> `film` / `github` / `hatena` / `sepia` / `mono` は将来追加予定の値であり、
-> 現時点で渡すと `400` が返る。
+> **Phase 1 status:** 5 テーマ（`film` / `github` / `hatena` / `sepia` / `mono`）を
+> 実装済み。デフォルトは `film`。`accent` の自動切り替えは `theme=film` のときだけ
+> `source` を見る形で動く（`source=github`→くすんだ緑、`source=hatena`→くすんだ青）。
+> 他のテーマはテーマ自身の配色を優先し、source による accent 切り替えは行わない。
+> 明示的な `accent` パラメータは Phase 1 では入れない（Phase 3 で再検討）。
 
-- `theme`: `film`, `github`, `hatena`, `sepia`, `mono`（将来）
-- `accent`: 自動または明示指定
-- `background`: 自動または明示指定
-- `ink`: 文字と線の色
+- `theme`: `film`, `github`, `hatena`, `sepia`, `mono`（実装済み・デフォルト `film`）
+- `accent`: `theme=film` のときのみ `source` で自動切り替え。明示指定は将来検討
+- `background`: theme で自動決定。明示指定は将来検討
+- `ink`: 文字と線の色。theme で自動決定
 
 例:
 
-- `/api/graph?user=kako-jun&source=github&theme=film`
-- `/api/graph?user=kako-jun&source=github&theme=github`
-- `/api/graph?user=kako-jun&source=hatena&theme=film&accent=%233a6ea5`
+- `/api/graph?user=kako-jun&source=github&theme=film` — film 配色 + GitHub 緑のアクセント
+- `/api/graph?user=kako-jun&source=github&theme=github` — GitHub 草配色（accent 固定）
+- `/api/graph?user=kako-jun&source=hatena&theme=film` — film 配色 + はてな青のアクセント
 
 ## Core Modes
 
@@ -110,7 +112,7 @@ GitHub のプロフィール右上や README に貼る主戦場。
 
 - `user`
 - `source=github|hatena`
-- `theme=deathnote`（Phase 0 で実装済み。`film|github|hatena|sepia|mono` は将来追加予定）
+- `theme=film|github|hatena|sepia|mono`（Phase 1 で実装済み、デフォルト `film`）
 - `size=small|medium|large`
 - `mode=auto`
 - `loop=true`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kira-activity",
   "version": "1.0.0",
-  "description": "Death Note L-style activity graph widget - Animated WebP generator for GitHub profiles",
+  "description": "Death Note analysis-screen inspired activity widget — animated WebP and iframe embed for GitHub/Hatena profiles",
   "main": "src/server.js",
   "type": "module",
   "scripts": {
@@ -13,10 +13,12 @@
   },
   "keywords": [
     "github",
+    "hatena",
     "activity",
     "graph",
     "widget",
     "webp",
+    "iframe",
     "death-note",
     "visualization"
   ],

--- a/src/renderer/embed.html
+++ b/src/renderer/embed.html
@@ -5,11 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>KIRA Activity - Embed</title>
   <style>
+    :root {
+      --kira-bg: __PALETTE_BG__;
+      --kira-ink: __PALETTE_INK__;
+      --kira-grid: __PALETTE_GRID__;
+      --kira-accent: __PALETTE_ACCENT__;
+      --kira-highlight: __PALETTE_HIGHLIGHT__;
+    }
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html, body { width: 100%; height: 100%; }
     body {
-      background: #000;
-      color: #ccc;
+      background: var(--kira-bg);
+      color: var(--kira-ink);
       font-family: 'Courier New', monospace;
       overflow: hidden;
     }
@@ -27,16 +34,16 @@
       left: 16px;
       font-size: 12px;
       letter-spacing: 0.1em;
-      color: #888;
+      color: var(--kira-ink);
       z-index: 10;
     }
-    #header strong { color: #f44; }
+    #header strong { color: var(--kira-highlight); }
     #panel {
       width: 80%;
       max-width: 720px;
       aspect-ratio: 16 / 9;
-      border: 1px solid #333;
-      background: #0a0a0a;
+      border: 1px solid var(--kira-grid);
+      background: var(--kira-bg);
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -45,15 +52,15 @@
       padding: 24px;
       text-align: center;
     }
-    #title { color: #f44; font-size: 18px; letter-spacing: 0.15em; }
-    #subtitle { color: #888; font-size: 13px; }
+    #title { color: var(--kira-highlight); font-size: 18px; letter-spacing: 0.15em; }
+    #subtitle { color: var(--kira-ink); font-size: 13px; opacity: 0.7; }
     #view-label {
-      color: #4f4;
+      color: var(--kira-accent);
       font-size: 28px;
       letter-spacing: 0.2em;
       text-transform: uppercase;
     }
-    #note { color: #555; font-size: 11px; margin-top: 8px; }
+    #note { color: var(--kira-grid); font-size: 11px; margin-top: 8px; }
     #carousel {
       position: absolute;
       bottom: 20px;
@@ -66,10 +73,10 @@
     .dot {
       width: 8px; height: 8px;
       border-radius: 50%;
-      background: #333;
+      background: var(--kira-grid);
       transition: background 0.2s;
     }
-    .dot.active { background: #f44; }
+    .dot.active { background: var(--kira-highlight); }
   </style>
 </head>
 <body>
@@ -79,7 +86,7 @@
       <div id="title">ANALYZING PATTERN</div>
       <div id="subtitle" data-field="subtitle">user / source</div>
       <div id="view-label" data-field="view">AUTO</div>
-      <div id="note">Phase 0 placeholder. Full visualization arrives in Phase 2.</div>
+      <div id="note">Phase 1 palette preview. Full visualization arrives in Phase 2.</div>
     </div>
     <div id="carousel">
       <div class="dot" data-view="kira"></div>

--- a/src/renderer/embed.html
+++ b/src/renderer/embed.html
@@ -85,7 +85,7 @@
     <div id="panel">
       <div id="title">ANALYZING PATTERN</div>
       <div id="subtitle" data-field="subtitle">user / source</div>
-      <div id="view-label" data-field="view">AUTO</div>
+      <div id="view-label" data-field="view">KIRA</div>
       <div id="note">Phase 1 palette preview. Full visualization arrives in Phase 2.</div>
     </div>
     <div id="carousel">

--- a/src/renderer/graph.html
+++ b/src/renderer/graph.html
@@ -117,9 +117,13 @@
     root.style.setProperty('--kira-highlight', PALETTE.highlight);
 
     // Three.js wants 0xRRGGBB ints, not '#rrggbb' strings.
-    function hexToInt(h) { return parseInt(h.slice(1), 16); }
+    function hexToInt(h) {
+      if (typeof h !== 'string' || !/^#[0-9a-fA-F]{6}$/.test(h)) return 0x000000;
+      return parseInt(h.slice(1), 16);
+    }
+    // ink は CSS variable 側で `.info` 等のテキストに適用される。
+    // Three.js scene では使わないので int 化はしない。
     const COLOR_BG = hexToInt(PALETTE.background);
-    const COLOR_INK = hexToInt(PALETTE.ink);
     const COLOR_GRID = hexToInt(PALETTE.grid);
     const COLOR_ACCENT = hexToInt(PALETTE.accent);
     const COLOR_HIGHLIGHT = hexToInt(PALETTE.highlight);
@@ -445,11 +449,25 @@
     }
 
     /**
-     * Add 3D axes
+     * Add 3D axes.
+     *
+     * THREE.AxesHelper hardcodes R/G/B for X/Y/Z, which clashes with the
+     * mono / film / sepia palettes. We draw three plain lines in the grid
+     * token instead so axes stay on-theme across all themes.
      */
     function addAxes3D() {
-      const axesHelper = new THREE.AxesHelper(10);
-      scene.add(axesHelper);
+      const len = 10;
+      const mat = new THREE.LineBasicMaterial({ color: COLOR_GRID });
+      [
+        [[0,0,0],[len,0,0]],
+        [[0,0,0],[0,len,0]],
+        [[0,0,0],[0,0,len]]
+      ].forEach(([a, b]) => {
+        const g = new THREE.BufferGeometry().setFromPoints([
+          new THREE.Vector3(...a), new THREE.Vector3(...b)
+        ]);
+        scene.add(new THREE.Line(g, mat));
+      });
     }
 
     // Start when page loads

--- a/src/renderer/graph.html
+++ b/src/renderer/graph.html
@@ -12,8 +12,8 @@
     }
 
     body {
-      background: #000;
-      color: #0f0;
+      background: var(--kira-bg, #000);
+      color: var(--kira-ink, #ccc);
       font-family: 'Courier New', monospace;
       overflow: hidden;
     }
@@ -32,15 +32,13 @@
       position: absolute;
       top: 20px;
       left: 20px;
-      color: #0f0;
-      text-shadow: 0 0 10px #0f0;
+      color: var(--kira-ink, #ccc);
       z-index: 10;
     }
 
     .title {
       font-size: 24px;
-      color: #f00;
-      text-shadow: 0 0 20px #f00;
+      color: var(--kira-highlight, #f00);
       margin-bottom: 10px;
     }
 
@@ -54,7 +52,7 @@
     }
 
     .random-item {
-      color: #0f0;
+      color: var(--kira-accent, #0f0);
       font-size: 12px;
       opacity: 0;
       animation: fadeIn 0.5s forwards;
@@ -75,7 +73,7 @@
       display: inline-block;
       width: 20px;
       height: 20px;
-      border: 1px solid #0f0;
+      border: 1px solid var(--kira-grid, #0f0);
       margin: 1px;
       transition: background-color 0.3s;
     }
@@ -98,7 +96,33 @@
     // Internal numeric scene ID (1=random list, 2=month, 3=week, 4=kira/3D).
     // Public view names (kira/month/week) are mapped to these IDs in the server.
     const SCENE = window.RENDER_SCENE || 4;
-    const THEME = window.RENDER_THEME || 'deathnote';
+    const THEME = window.RENDER_THEME || 'film';
+    // Palette tokens for the active theme/source. The server resolves these
+    // (see src/renderer/palette.js) and injects them; we fall back to film
+    // values if rendering this template directly without the server.
+    const PALETTE = window.RENDER_PALETTE || {
+      background: '#e8e2d4',
+      ink: '#3a322a',
+      grid: '#bfb6a3',
+      accent: '#7a5c3a',
+      highlight: '#c14a3a'
+    };
+
+    // Mirror palette tokens to CSS variables so the stylesheet picks them up.
+    const root = document.documentElement;
+    root.style.setProperty('--kira-bg', PALETTE.background);
+    root.style.setProperty('--kira-ink', PALETTE.ink);
+    root.style.setProperty('--kira-grid', PALETTE.grid);
+    root.style.setProperty('--kira-accent', PALETTE.accent);
+    root.style.setProperty('--kira-highlight', PALETTE.highlight);
+
+    // Three.js wants 0xRRGGBB ints, not '#rrggbb' strings.
+    function hexToInt(h) { return parseInt(h.slice(1), 16); }
+    const COLOR_BG = hexToInt(PALETTE.background);
+    const COLOR_INK = hexToInt(PALETTE.ink);
+    const COLOR_GRID = hexToInt(PALETTE.grid);
+    const COLOR_ACCENT = hexToInt(PALETTE.accent);
+    const COLOR_HIGHLIGHT = hexToInt(PALETTE.highlight);
 
     // Global variables
     let scene, camera, renderer;
@@ -196,15 +220,19 @@
               scene.remove(oldMesh);
             }
 
-            // Create new mesh with updated intensity
+            // Create new mesh with updated intensity. Color blends from
+            // grid (low) to accent (mid) to highlight (peak) so the heatmap
+            // reads as accent-driven across all themes.
             const geometry = new THREE.PlaneGeometry(0.4, 0.4);
             const intensity = Math.min(totalCount / 10, 1);
-            const color = new THREE.Color().setHSL(0.3, 1, 0.2 + intensity * 0.6);
+            const baseColor = new THREE.Color(COLOR_ACCENT);
+            const peakColor = new THREE.Color(COLOR_HIGHLIGHT);
+            const color = baseColor.clone().lerp(peakColor, intensity);
             const material = new THREE.MeshBasicMaterial({
               color,
               side: THREE.DoubleSide,
               transparent: true,
-              opacity: 0.8 + intensity * 0.2
+              opacity: 0.6 + intensity * 0.4
             });
             const mesh = new THREE.Mesh(geometry, material);
 
@@ -255,14 +283,14 @@
 
       // Create line
       const geometry = new THREE.BufferGeometry().setFromPoints(points);
-      const material = new THREE.LineBasicMaterial({ color: 0x00ff00, linewidth: 2 });
+      const material = new THREE.LineBasicMaterial({ color: COLOR_ACCENT, linewidth: 2 });
       const line = new THREE.Line(geometry, material);
       scene.add(line);
 
       // Add points
       points.forEach((point, index) => {
         const dotGeometry = new THREE.SphereGeometry(0.15, 16, 16);
-        const dotMaterial = new THREE.MeshBasicMaterial({ color: 0xff0000 });
+        const dotMaterial = new THREE.MeshBasicMaterial({ color: COLOR_HIGHLIGHT });
         const dot = new THREE.Mesh(dotGeometry, dotMaterial);
         dot.position.copy(point);
         scene.add(dot);
@@ -308,10 +336,11 @@
           points.push(new THREE.Vector3(x, y, z));
         });
 
-        // Create line
+        // Create line — accent for the bulk of the geometry,
+        // highlight for the peak dots. Per-day chroma variation is a
+        // Phase 2/3 refinement; Phase 1 keeps the palette honest.
         const geometry = new THREE.BufferGeometry().setFromPoints(points);
-        const color = new THREE.Color().setHSL(parseInt(dayIndex) / 7, 0.8, 0.5);
-        const material = new THREE.LineBasicMaterial({ color, linewidth: 2 });
+        const material = new THREE.LineBasicMaterial({ color: COLOR_ACCENT, linewidth: 2 });
         const line = new THREE.Line(geometry, material);
         scene.add(line);
 
@@ -319,7 +348,7 @@
         points.forEach((point, index) => {
           if (dayCells[index].count > 0) {
             const dotGeometry = new THREE.SphereGeometry(0.1, 8, 8);
-            const dotMaterial = new THREE.MeshBasicMaterial({ color });
+            const dotMaterial = new THREE.MeshBasicMaterial({ color: COLOR_HIGHLIGHT });
             const dot = new THREE.Mesh(dotGeometry, dotMaterial);
             dot.position.copy(point);
             scene.add(dot);
@@ -360,7 +389,7 @@
       const container = document.getElementById('container');
 
       scene = new THREE.Scene();
-      scene.background = new THREE.Color(0x000000);
+      scene.background = new THREE.Color(COLOR_BG);
 
       camera = new THREE.PerspectiveCamera(
         75,
@@ -390,7 +419,7 @@
         new THREE.Vector3(-5, -3, 0),
         new THREE.Vector3(5, -3, 0)
       ]);
-      const xMaterial = new THREE.LineBasicMaterial({ color: 0x444444 });
+      const xMaterial = new THREE.LineBasicMaterial({ color: COLOR_GRID });
       const xAxis = new THREE.Line(xGeometry, xMaterial);
       scene.add(xAxis);
 
@@ -399,7 +428,7 @@
         new THREE.Vector3(-3, -3, 0),
         new THREE.Vector3(-3, 3, 0)
       ]);
-      const yMaterial = new THREE.LineBasicMaterial({ color: 0x444444 });
+      const yMaterial = new THREE.LineBasicMaterial({ color: COLOR_GRID });
       const yAxis = new THREE.Line(yGeometry, yMaterial);
       scene.add(yAxis);
     }
@@ -408,7 +437,9 @@
      * Add 3D grid
      */
     function addGrid3D() {
-      const gridHelper = new THREE.GridHelper(20, 20, 0x00ff00, 0x003300);
+      // Both center and outer grid lines use the grid token; depth is
+      // implied by the geometry, not by a chroma split.
+      const gridHelper = new THREE.GridHelper(20, 20, COLOR_GRID, COLOR_GRID);
       gridHelper.position.y = -0.1;
       scene.add(gridHelper);
     }

--- a/src/renderer/palette.js
+++ b/src/renderer/palette.js
@@ -1,0 +1,114 @@
+/**
+ * Palette tokens for the visual direction defined in docs/visual-direction.md.
+ *
+ * Each theme defines five tokens:
+ *   - background: outermost surface (canvas / page background)
+ *   - ink:        text and primary line color
+ *   - grid:       axis / grid / scaffolding lines
+ *   - accent:     main data color (lines, bars, primary dots)
+ *   - highlight:  emphasis color (peaks, alerts, secondary dots)
+ *
+ * Source-aware accent (Phase 1 scope): only `theme=film` reacts to `source`.
+ * The other themes already encode a strong visual identity, so we keep their
+ * accent fixed to avoid muddying that identity. This matches the acceptance
+ * criterion "Keep film-like base colors even when accents change" — the rule
+ * applies to the film theme, where the cream + ink base must stay constant
+ * while accents shift between github-green and hatena-blue tones.
+ */
+
+const HEX6 = /^#[0-9a-fA-F]{6}$/;
+
+const THEMES = Object.freeze({
+  // Cream + dark gray-brown ink. The "investigation document" mood from the
+  // live-action Death Note analysis screen.
+  film: Object.freeze({
+    background: '#e8e2d4',
+    ink: '#3a322a',
+    grid: '#bfb6a3',
+    accent: '#7a5c3a',
+    highlight: '#c14a3a'
+  }),
+  // GitHub dark contribution-graph palette.
+  github: Object.freeze({
+    background: '#0d1117',
+    ink: '#c9d1d9',
+    grid: '#30363d',
+    accent: '#39d353',
+    highlight: '#7ee787'
+  }),
+  // Hatena Bookmark inspired light blue palette.
+  hatena: Object.freeze({
+    background: '#f4f6f8',
+    ink: '#1f2937',
+    grid: '#cbd5e1',
+    accent: '#2c7eb8',
+    highlight: '#5eb1e0'
+  }),
+  // Warm sepia paper.
+  sepia: Object.freeze({
+    background: '#f3ead4',
+    ink: '#3a2a18',
+    grid: '#c8b890',
+    accent: '#8a5a2a',
+    highlight: '#d09c5a'
+  }),
+  // Neutral mono — a calm fallback with no chroma.
+  mono: Object.freeze({
+    background: '#f5f5f5',
+    ink: '#222222',
+    grid: '#bcbcbc',
+    accent: '#000000',
+    highlight: '#666666'
+  })
+});
+
+/**
+ * Source-aware accent overrides for the film theme. Tuned to read as
+ * "film palette + a hint of github/hatena" rather than the source's own
+ * brand color. The base (background, ink, grid, highlight) stays film.
+ */
+const FILM_ACCENT_BY_SOURCE = Object.freeze({
+  github: '#3a7d44', // muted green that lives next to film's brown
+  hatena: '#3a6ea5'  // muted blue that lives next to film's brown
+});
+
+/**
+ * Resolve the palette for a given (theme, source) pair.
+ *
+ * @param {string} theme  — one of VALID_THEMES; falls back to 'film'
+ * @param {string} [source] — 'github' or 'hatena'; only consulted when theme=film
+ * @returns {{background:string, ink:string, grid:string, accent:string, highlight:string}}
+ */
+export function getPalette(theme, source) {
+  const base = THEMES[theme] ?? THEMES.film;
+  let accent = base.accent;
+  if (theme === 'film' && source && FILM_ACCENT_BY_SOURCE[source]) {
+    accent = FILM_ACCENT_BY_SOURCE[source];
+  }
+  // Return a plain (mutable) copy so callers cannot accidentally freeze the
+  // module-level constants by passing this through some downstream API.
+  return {
+    background: base.background,
+    ink: base.ink,
+    grid: base.grid,
+    accent,
+    highlight: base.highlight
+  };
+}
+
+/**
+ * Verify that a palette only contains six-digit hex colors. Used as an
+ * extra defense before injecting values directly into a CSS context.
+ * Returns the input unchanged if all values are safe; otherwise replaces
+ * the offending entry with '#000000'.
+ */
+export function sanitizePalette(palette) {
+  const out = {};
+  for (const key of ['background', 'ink', 'grid', 'accent', 'highlight']) {
+    const v = palette[key];
+    out[key] = typeof v === 'string' && HEX6.test(v) ? v : '#000000';
+  }
+  return out;
+}
+
+export const VALID_THEMES = Object.freeze(Object.keys(THEMES));

--- a/src/renderer/palette.js
+++ b/src/renderer/palette.js
@@ -66,6 +66,10 @@ const THEMES = Object.freeze({
  * Source-aware accent overrides for the film theme. Tuned to read as
  * "film palette + a hint of github/hatena" rather than the source's own
  * brand color. The base (background, ink, grid, highlight) stays film.
+ *
+ * Film theme の中で source を表現する accent。pure な theme=github / theme=hatena
+ * よりトーンを落とし、film のクリーム+灰茶の base に馴染むよう調整している。
+ * 「film の中の github 寄り」と「pure github」は意図的に別色。
  */
 const FILM_ACCENT_BY_SOURCE = Object.freeze({
   github: '#3a7d44', // muted green that lives next to film's brown
@@ -80,7 +84,12 @@ const FILM_ACCENT_BY_SOURCE = Object.freeze({
  * @returns {{background:string, ink:string, grid:string, accent:string, highlight:string}}
  */
 export function getPalette(theme, source) {
-  const base = THEMES[theme] ?? THEMES.film;
+  // Defend against prototype keys like __proto__ / constructor / toString.
+  // Server already whitelists via VALID_THEMES, but this module is exported
+  // and could be called directly with attacker-controlled input.
+  const base = Object.prototype.hasOwnProperty.call(THEMES, theme)
+    ? THEMES[theme]
+    : THEMES.film;
   let accent = base.accent;
   if (theme === 'film' && source && FILM_ACCENT_BY_SOURCE[source]) {
     accent = FILM_ACCENT_BY_SOURCE[source];
@@ -104,7 +113,7 @@ export function getPalette(theme, source) {
  */
 export function sanitizePalette(palette) {
   const out = {};
-  for (const key of ['background', 'ink', 'grid', 'accent', 'highlight']) {
+  for (const key of Object.keys(THEMES.film)) {
     const v = palette[key];
     out[key] = typeof v === 'string' && HEX6.test(v) ? v : '#000000';
   }

--- a/src/renderer/webp-generator.js
+++ b/src/renderer/webp-generator.js
@@ -63,7 +63,8 @@ async function getBrowser() {
  *
  * @param {string} username - Username (GitHub or Hatena)
  * @param {string} source - 'github' or 'hatena'
- * @param {string} theme - Visualization theme ('film' | 'github' | 'hatena' | 'sepia' | 'mono')
+ * @param {string} theme - Visualization theme. VALID_THEMES のいずれか
+ *   ('film' | 'github' | 'hatena' | 'sepia' | 'mono')。それ以外は film にフォールバック。
  * @param {string} size - 'small' | 'medium' | 'large'
  * @param {object} [palette] - Resolved palette from server. If omitted, resolved here.
  * @returns {Promise<Buffer>} WebP buffer
@@ -100,7 +101,8 @@ export async function generateAnimatedWebP(username, source, theme, size, palett
  * @param {string} username
  * @param {string} source - 'github' | 'hatena'
  * @param {'kira'|'month'|'week'} view
- * @param {string} theme
+ * @param {string} theme - VALID_THEMES のいずれか
+ *   ('film' | 'github' | 'hatena' | 'sepia' | 'mono')。それ以外は film にフォールバック。
  * @param {string} size
  * @param {object} [palette] - Resolved palette from server. If omitted, resolved here.
  * @returns {Promise<Buffer>} WebP buffer
@@ -175,7 +177,11 @@ async function renderScene(processedData, scene, theme, size, palette) {
 
     await page.setContent(injectedHTML, { waitUntil: 'networkidle0' });
 
-    const waitTime = scene === 1 ? 2500 : (scene === 2 ? 4000 : (scene === 4 ? 4000 : 1500));
+    // scene=1 (random list) is dev-only auxiliary and not reachable via
+    // VIEW_TO_SCENE, so it does not appear here. month (2) / kira (4) wait
+    // longer because their animations layer over time; week (3) is a static
+    // line graph and renders in one frame.
+    const waitTime = scene === 2 || scene === 4 ? 4000 : 1500;
     await new Promise((resolve) => setTimeout(resolve, waitTime));
 
     const screenshot = await page.screenshot({

--- a/src/renderer/webp-generator.js
+++ b/src/renderer/webp-generator.js
@@ -6,6 +6,7 @@ import { dirname, join } from 'path';
 import { GitHubClient } from '../services/github.js';
 import { HatenaBookmarkClient } from '../services/hatena.js';
 import { DataProcessor } from '../utils/data-processor.js';
+import { getPalette, sanitizePalette } from './palette.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -62,12 +63,15 @@ async function getBrowser() {
  *
  * @param {string} username - Username (GitHub or Hatena)
  * @param {string} source - 'github' or 'hatena'
- * @param {string} theme - Visualization theme (e.g. 'deathnote')
+ * @param {string} theme - Visualization theme ('film' | 'github' | 'hatena' | 'sepia' | 'mono')
  * @param {string} size - 'small' | 'medium' | 'large'
+ * @param {object} [palette] - Resolved palette from server. If omitted, resolved here.
  * @returns {Promise<Buffer>} WebP buffer
  */
-export async function generateAnimatedWebP(username, source, theme, size) {
+export async function generateAnimatedWebP(username, source, theme, size, palette) {
   console.log(`Generating animated WebP for ${username} (${source}, theme=${theme})...`);
+
+  const resolvedPalette = sanitizePalette(palette ?? getPalette(theme, source));
 
   const activityData = await fetchActivityData(username, source);
   const processedData = DataProcessor.process(activityData);
@@ -76,7 +80,7 @@ export async function generateAnimatedWebP(username, source, theme, size) {
   const startTime = Date.now();
 
   const framePromises = ALL_VIEWS.map((view) =>
-    renderScene(processedData, VIEW_TO_SCENE[view], theme, size)
+    renderScene(processedData, VIEW_TO_SCENE[view], theme, size, resolvedPalette)
   );
 
   const frames = await Promise.all(framePromises);
@@ -98,9 +102,10 @@ export async function generateAnimatedWebP(username, source, theme, size) {
  * @param {'kira'|'month'|'week'} view
  * @param {string} theme
  * @param {string} size
+ * @param {object} [palette] - Resolved palette from server. If omitted, resolved here.
  * @returns {Promise<Buffer>} WebP buffer
  */
-export async function generateView(username, source, view, theme, size) {
+export async function generateView(username, source, view, theme, size, palette) {
   const scene = VIEW_TO_SCENE[view];
   if (!scene) {
     throw new Error(`Unknown view: ${view}`);
@@ -108,10 +113,12 @@ export async function generateView(username, source, view, theme, size) {
 
   console.log(`Generating view '${view}' for ${username} (${source})...`);
 
+  const resolvedPalette = sanitizePalette(palette ?? getPalette(theme, source));
+
   const activityData = await fetchActivityData(username, source);
   const processedData = DataProcessor.process(activityData);
 
-  const frame = await renderScene(processedData, scene, theme, size);
+  const frame = await renderScene(processedData, scene, theme, size, resolvedPalette);
 
   const webpBuffer = await sharp(frame)
     .webp({ quality: 90 })
@@ -140,7 +147,7 @@ async function fetchActivityData(username, source) {
  * Render a specific scene using Puppeteer (reuses browser).
  * Internal `scene` is a numeric scene ID consumed by graph.html.
  */
-async function renderScene(processedData, scene, theme, size) {
+async function renderScene(processedData, scene, theme, size, palette) {
   const browser = await getBrowser();
   const page = await browser.newPage();
 
@@ -148,14 +155,21 @@ async function renderScene(processedData, scene, theme, size) {
     const dimensions = getSizeDimensions(size);
     await page.setViewport(dimensions);
 
+    // Same XSS-safe pattern used for ACTIVITY_DATA / RENDER_THEME (see PR #11):
+    // JSON-encode then escape `<` to `<` so a `</script>` payload cannot
+    // break out of the injected script context. Palette values are already
+    // hex-only via sanitizePalette() but we still pipe them through the same
+    // escape for symmetry.
     const safeData = JSON.stringify(processedData).replace(/</g, '\\u003c');
     const safeTheme = JSON.stringify(theme).replace(/</g, '\\u003c');
+    const safePalette = JSON.stringify(palette).replace(/</g, '\\u003c');
     const injectedHTML = HTML_TEMPLATE.replace(
       '</head>',
       `<script>
         window.ACTIVITY_DATA = ${safeData};
         window.RENDER_SCENE = ${scene};
         window.RENDER_THEME = ${safeTheme};
+        window.RENDER_PALETTE = ${safePalette};
       </script></head>`
     );
 

--- a/src/server.js
+++ b/src/server.js
@@ -5,6 +5,7 @@ import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { generateAnimatedWebP, generateView, shutdown as shutdownRenderer } from './renderer/webp-generator.js';
+import { getPalette, sanitizePalette, VALID_THEMES as PALETTE_THEMES } from './renderer/palette.js';
 import { CacheManager } from './services/cache.js';
 
 dotenv.config();
@@ -17,7 +18,7 @@ const cache = new CacheManager();
 
 // Shared query param contract
 const VALID_SOURCES = new Set(['github', 'hatena']);
-const VALID_THEMES = new Set(['deathnote']);
+const VALID_THEMES = new Set(PALETTE_THEMES);
 const VALID_SIZES = new Set(['small', 'medium', 'large']);
 const VALID_VIEWS = new Set(['kira', 'month', 'week', 'auto']);
 // GitHub username spec: 1-39 chars, alphanumerics and hyphens.
@@ -27,7 +28,7 @@ const USER_PATTERN = /^[A-Za-z0-9_-]{1,39}$/;
 function parseSharedParams(c) {
   const user = c.req.query('user');
   const source = c.req.query('source') || 'github';
-  const theme = c.req.query('theme') || 'deathnote';
+  const theme = c.req.query('theme') || 'film';
   const size = c.req.query('size') || 'medium';
   const view = c.req.query('view') || 'auto';
 
@@ -50,7 +51,11 @@ function parseSharedParams(c) {
     return { error: `invalid view: ${view}` };
   }
 
-  return { user, source, theme, size, view };
+  // Resolve palette once per request and pass it down. Sanitized so any
+  // accidental non-hex value is replaced before it reaches CSS injection.
+  const palette = sanitizePalette(getPalette(theme, source));
+
+  return { user, source, theme, size, view, palette };
 }
 
 // Eager load template at module init. Failing fast at startup is preferable
@@ -59,24 +64,42 @@ const EMBED_TEMPLATE = readFileSync(join(__dirname, 'renderer', 'embed.html'), '
 
 /**
  * Render the embed template by replacing __USER__ / __SOURCE__ / __THEME__ /
- * __SIZE__ / __VIEW__ placeholders in a single pass. Each value is
- * JSON-stringified and `<` is escaped to `<` so a payload like
- * `?user=</script>...` cannot break out of the script context.
+ * __SIZE__ / __VIEW__ placeholders (script context, JSON-encoded) and
+ * __PALETTE_*__ placeholders (CSS context, raw hex strings) in a single pass.
+ *
+ * Two contexts, two escaping strategies:
+ *   - Script-context placeholders (USER/SOURCE/THEME/SIZE/VIEW) are
+ *     JSON.stringify'd and have `<` escaped to `<` so a payload like
+ *     `?user=</script>...` cannot break out of the script.
+ *   - CSS-context placeholders (PALETTE_*) carry palette tokens that come
+ *     from sanitizePalette() and are guaranteed `^#[0-9a-fA-F]{6}$`. They
+ *     are emitted raw, suitable for `--kira-bg: #xxxxxx;`.
  *
  * Single-pass replacement also prevents placeholder collisions: a value such
  * as `?user=zzz__VIEW__zzz` cannot accidentally inject into a later
  * placeholder slot the way chained `.replace()` calls allowed.
  */
 function renderEmbed(params) {
-  const map = {
+  const scriptMap = {
     USER: params.user,
     SOURCE: params.source,
     THEME: params.theme,
     SIZE: params.size,
     VIEW: params.view
   };
-  return EMBED_TEMPLATE.replace(/__(USER|SOURCE|THEME|SIZE|VIEW)__/g, (_, k) =>
-    JSON.stringify(map[k]).replace(/</g, '\\u003c')
+  const cssMap = {
+    PALETTE_BG: params.palette.background,
+    PALETTE_INK: params.palette.ink,
+    PALETTE_GRID: params.palette.grid,
+    PALETTE_ACCENT: params.palette.accent,
+    PALETTE_HIGHLIGHT: params.palette.highlight
+  };
+  return EMBED_TEMPLATE.replace(
+    /__(USER|SOURCE|THEME|SIZE|VIEW|PALETTE_BG|PALETTE_INK|PALETTE_GRID|PALETTE_ACCENT|PALETTE_HIGHLIGHT)__/g,
+    (_, k) => {
+      if (k in cssMap) return cssMap[k];
+      return JSON.stringify(scriptMap[k]).replace(/</g, '\\u003c');
+    }
   );
 }
 
@@ -114,7 +137,7 @@ app.get('/api/graph', async (c) => {
     return c.json({ error: params.error }, 400);
   }
 
-  const { user, source, theme, size, view } = params;
+  const { user, source, theme, size, view, palette } = params;
 
   try {
     const cacheKey = `graph_${source}_${user}_${theme}_${size}_${view}`;
@@ -129,8 +152,8 @@ app.get('/api/graph', async (c) => {
     }
 
     const webpBuffer = view === 'auto'
-      ? await generateAnimatedWebP(user, source, theme, size)
-      : await generateView(user, source, view, theme, size);
+      ? await generateAnimatedWebP(user, source, theme, size, palette)
+      : await generateView(user, source, view, theme, size, palette);
 
     cache.set(cacheKey, webpBuffer);
 
@@ -215,7 +238,7 @@ app.get('/', (c) => {
       <h3>Shared parameters</h3>
       <p><code>user</code> required</p>
       <p><code>source</code> github | hatena (default github)</p>
-      <p><code>theme</code> deathnote (default deathnote)</p>
+      <p><code>theme</code> film | github | hatena | sepia | mono (default film)</p>
       <p><code>size</code> small | medium | large (default medium)</p>
       <p><code>view</code> kira | month | week | auto (default auto)</p>
     </div>


### PR DESCRIPTION
## 関連 Issue
closes #3

## 変更内容

### Palette system 導入
- 新規 `src/renderer/palette.js` — 5 テーマ × 5 トークン (`background` / `ink` / `grid` / `accent` / `highlight`)
- `getPalette(theme, source)` resolver で `theme=film` の場合のみ source 連動アクセント
  - `source=github` → 緑系 `#3a7d44`（film に馴染ませた）
  - `source=hatena` → 青系 `#3a6ea5`
- `sanitizePalette` で hex 値を厳格バリデート（CSS 注入対策）

### テーマ
| theme | 用途 |
|---|---|
| `film` | デフォルト。クリーム + 灰茶（捜査資料・分析モニタ） |
| `github` | GitHub 緑系 |
| `hatena` | Hatena 青系 |
| `sepia` | セピア調 |
| `mono` | モノクロ |

旧 `theme=deathnote` は **削除**（後方互換なし）。

### コード変更
- `src/server.js` — `VALID_THEMES` を palette.js から import、デフォルト `theme=film`、`parseSharedParams` が palette を resolve
- `src/renderer/embed.html` — `:root` の CSS 変数 `--kira-bg` / `--kira-ink` / `--kira-grid` / `--kira-accent` / `--kira-highlight` を注入し、ハードコード色を全て変数参照に
- `src/renderer/graph.html` — `window.RENDER_PALETTE` を読み、scene2/3/4 の主要色をパレット駆動に
- `src/renderer/webp-generator.js` — `palette` 引数を受け取り `window.RENDER_PALETTE` を注入

### ドキュメント
- `README.md` / `CLAUDE.md` / `docs/visual-direction.md` を Phase 1 仕様に更新、`deathnote` の言及を削除

## Acceptance criteria

- [x] `theme=film` がクリーム + 灰茶 (`#e8e2d4` / `#3a322a`) で動く
- [x] `film + source=github` と `film + source=hatena` で accent が visibly 異なる (`#3a7d44` vs `#3a6ea5`)、bg / ink は同一
- [x] Visual tokens が `palette.js` に集約済み（ハードコードなし）
- [x] embed と /api/graph が同じ resolver を経由

## 動作確認

```
theme=film       → 200
theme=github     → 200
theme=hatena     → 200
theme=sepia      → 200
theme=mono       → 200
theme=deathnote  → 400  (旧仕様削除)

film + source=github: --kira-accent: #3a7d44
film + source=hatena: --kira-accent: #3a6ea5
```

## スコープ外（Phase 2/3 へ）

- scene1..4 の細部（ツールチップ、ラベル等）の palette 化
- ユーザー明示の `accent` パラメータ（visual-direction.md の Phase 3 「カスタム配色」）
- デモページのリファイン