### PR TITLE
Phase 4: add transitions and iframe carousel controls (#4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,8 +188,16 @@ Node.js より 2–3 倍高速（`bun src/server.js`）。
 ### src/renderer/embed.html
 
 - `/embed` が返す HTML
-- Phase 0 では view 切替の枠組みだけ（ラベル＋カルーセル）
-- Phase 2 で本格的な Three.js 表示に置き換える
+- `<img id="kira-image">` に `/api/graph` を読み込ませて表示する。Three.js は
+  サーバ側 Puppeteer がすでに WebP 化しているので、iframe では再実行しない
+- `view=auto`: animated WebP を表示し、JS が `Date.now()` 起点の経過時間から
+  カルーセルドットを RAF ループで同期する。サイクル長は kira 4s + month 2.5s
+  + week 5s = 11.5s で `webp-generator.js` の dwell time と一致させる
+- `view=kira|month|week`: 単一ビュー WebP を表示し、該当ドットだけ active
+- ドットクリック: auto 同期を停止し、CSS opacity フェード（400ms ease-in-out）
+  で単一ビュー WebP に差し替え。URL は変更しない（埋め込み先が制御するため）
+- 4 ビュー（auto + kira + month + week）を初期 load 時に並列 pre-warm して
+  サーバ側 NodeCache（TTL 3600s）をウォームアップ
 
 ### src/utils/data-processor.js
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,14 +190,18 @@ Node.js より 2–3 倍高速（`bun src/server.js`）。
 - `/embed` が返す HTML
 - `<img id="kira-image">` に `/api/graph` を読み込ませて表示する。Three.js は
   サーバ側 Puppeteer がすでに WebP 化しているので、iframe では再実行しない
-- `view=auto`: animated WebP を表示し、JS が `Date.now()` 起点の経過時間から
-  カルーセルドットを RAF ループで同期する。サイクル長は kira 4s + month 2.5s
-  + week 5s = 11.5s で `webp-generator.js` の dwell time と一致させる
+- `view=auto`: クライアント側で単一ビュー WebP（kira / month / week）をサイクル
+  時間ごとに `<img>.src` swap し、ドットと画像を完全同期させる。`performance.now()`
+  起点の RAF ループ。サイクル長は kira 4s + month 2.5s + week 5s = 11.5s で
+  `webp-generator.js` の dwell time と一致させる。Phase 5 で真の animated WebP が
+  返るようになれば auto はサーバ側動画 1 本に切り替える
 - `view=kira|month|week`: 単一ビュー WebP を表示し、該当ドットだけ active
-- ドットクリック: auto 同期を停止し、CSS opacity フェード（400ms ease-in-out）
-  で単一ビュー WebP に差し替え。URL は変更しない（埋め込み先が制御するため）
-- 4 ビュー（auto + kira + month + week）を初期 load 時に並列 pre-warm して
-  サーバ側 NodeCache（TTL 3600s）をウォームアップ
+- ドットクリック / Enter / Space: auto 同期を停止し、CSS opacity フェード
+  （400ms ease-in-out）で単一ビュー WebP に差し替え。`swapSeq` トークンで
+  重複 swap の race を防止。URL は変更しない（埋め込み先が制御するため）
+- 3 つの単一ビュー（kira + month + week）を初期 load 時に並列 pre-warm して
+  サーバ側 NodeCache（TTL 3600s）をウォームアップ。`auto` は embed 側で使わない
+- ロード失敗時は `#error-label` に "unable to load activity" を控えめに表示
 
 ### src/utils/data-processor.js
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ npm start
 <iframe src="https://example.com/embed?user=YOUR_USERNAME"></iframe>
 ```
 
+`/embed` は `/api/graph` を `<img>` として読み込み、`view=auto` ではアニメーション
+WebP を再生しつつ、下部のカルーセルドットが現在のビューに同期する。ドットを
+クリックすると自動再生を停止して `kira` / `month` / `week` の単一ビュー WebP に
+opacity フェードで切り替わる。`view=kira|month|week` を URL に渡すと最初から
+特定モードに固定できる。
+
 ### README に画像として貼る
 
 ```markdown

--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ npm start
 <iframe src="https://example.com/embed?user=YOUR_USERNAME"></iframe>
 ```
 
-`/embed` は `/api/graph` を `<img>` として読み込み、`view=auto` ではアニメーション
-WebP を再生しつつ、下部のカルーセルドットが現在のビューに同期する。ドットを
-クリックすると自動再生を停止して `kira` / `month` / `week` の単一ビュー WebP に
-opacity フェードで切り替わる。`view=kira|month|week` を URL に渡すと最初から
-特定モードに固定できる。
+`/embed` は `/api/graph` を `<img>` として読み込む。`view=auto` のときは embed 側が
+クライアントサイドで単一ビュー WebP（`kira` / `month` / `week`）をサイクル時間ごとに
+swap し、下部のカルーセルドットと画像を完全同期させる（Phase 5 で webp-generator が
+真の animated WebP を返すようになれば、auto モードはそれを使うよう移行する）。
+ドットをクリックすると自動再生を停止して該当ビューの単一 WebP に opacity フェードで
+切り替わる。`view=kira|month|week` を URL に渡すと最初から特定モードに固定できる。
 
 ### README に画像として貼る
 

--- a/docs/visual-direction.md
+++ b/docs/visual-direction.md
@@ -153,7 +153,7 @@ GitHub のプロフィール右上や README に貼る主戦場。
 
 ### C. iframe App
 
-将来の対話的埋め込み。
+対話的埋め込み。
 
 - Endpoint 例: `/embed?user=...`
 - 自動再生あり
@@ -163,7 +163,7 @@ GitHub のプロフィール右上や README に貼る主戦場。
 
 iframe 用 UI:
 
-- 3 つの丸: `3D`, `Month`, `Week`
+- 3 つの丸: `kira`, `month`, `week`
 - 現在位置だけ少し濃くする
 - UI は小さく、主役を奪わない
 
@@ -172,6 +172,14 @@ iframe 用 UI:
 - `Hono` で HTML を返すシンプルな構成
 - フロントは素の `HTML/CSS/JS` + `Three.js`
 - Next.js は採用しない
+
+> **Phase 4 status:** 実装済み。`embed.html` は `<img id="kira-image">` に
+> `/api/graph` を読み込ませ、`view=auto` のときは animated WebP を表示しつつ
+> JS が経過時間からカルーセルドットを同期する。`view=kira|month|week` のときは
+> 単一ビュー WebP を表示し、該当ドットだけ active になる。ドットクリックは
+> auto 同期を停止し、CSS opacity フェード（400ms ease-in-out）で単一ビュー WebP
+> に切り替わる。読み込み待ちを隠すため、4 ビュー（auto + kira + month + week）
+> を初期 load 時に並列 pre-warm する。
 
 ## Information Architecture
 
@@ -190,6 +198,8 @@ iframe 用 UI:
 - カルーセル UI
 - 手動切り替え
 - モード固定 URL
+
+> Phase 4 で完了。`/embed` が `/api/graph` 駆動の対話的カルーセルとして動く。
 
 ### Phase 3
 

--- a/docs/visual-direction.md
+++ b/docs/visual-direction.md
@@ -174,12 +174,15 @@ iframe 用 UI:
 - Next.js は採用しない
 
 > **Phase 4 status:** 実装済み。`embed.html` は `<img id="kira-image">` に
-> `/api/graph` を読み込ませ、`view=auto` のときは animated WebP を表示しつつ
-> JS が経過時間からカルーセルドットを同期する。`view=kira|month|week` のときは
-> 単一ビュー WebP を表示し、該当ドットだけ active になる。ドットクリックは
-> auto 同期を停止し、CSS opacity フェード（400ms ease-in-out）で単一ビュー WebP
-> に切り替わる。読み込み待ちを隠すため、4 ビュー（auto + kira + month + week）
-> を初期 load 時に並列 pre-warm する。
+> `/api/graph` を読み込ませる。`view=auto` のときは embed 側がクライアントサイドで
+> 単一ビュー WebP（kira / month / week）をサイクル時間ごとに `<img>.src` ごと swap し、
+> ドットと画像を完全同期させる（`performance.now()` 起点 RAF ループ + fade swap）。
+> Phase 5 で webp-generator が真の animated WebP を返すようになれば、auto モードは
+> サーバ側の動画 1 本に切り替える。`view=kira|month|week` のときは単一ビュー WebP
+> を表示し、該当ドットだけ active になる。ドットクリックは auto 同期を停止し、
+> CSS opacity フェード（400ms ease-in-out）で単一ビュー WebP に切り替わる。
+> 読み込み待ちを隠すため、3 つの単一ビュー（kira + month + week）を初期 load 時に
+> 並列 pre-warm する（`auto` は embed 側で使わないので除外）。
 
 ## Information Architecture
 

--- a/src/renderer/embed.html
+++ b/src/renderer/embed.html
@@ -83,8 +83,22 @@
       cursor: pointer;
       transition: background 0.2s ease, transform 0.2s ease;
     }
-    .dot:hover { transform: scale(1.25); }
+    .dot:hover { transform: scale(1.1); }
     .dot.active { background: var(--kira-highlight); }
+    #error-label {
+      position: absolute;
+      bottom: 50px;
+      left: 50%;
+      transform: translateX(-50%);
+      color: var(--kira-grid);
+      font-size: 12px;
+      letter-spacing: 0.05em;
+      opacity: 0;
+      transition: opacity 0.3s ease-in-out;
+      pointer-events: none;
+      z-index: 5;
+    }
+    #error-label.visible { opacity: 1; }
   </style>
 </head>
 <body>
@@ -93,11 +107,12 @@
     <div id="subtitle" data-field="subtitle">user / source</div>
     <div id="panel">
       <img id="kira-image" alt="KIRA Activity visualization" />
+      <div id="error-label">unable to load activity</div>
     </div>
     <div id="carousel">
-      <div class="dot" data-view="kira"></div>
-      <div class="dot" data-view="month"></div>
-      <div class="dot" data-view="week"></div>
+      <div class="dot" data-view="kira" role="button" tabindex="0" aria-label="show kira view"></div>
+      <div class="dot" data-view="month" role="button" tabindex="0" aria-label="show month view"></div>
+      <div class="dot" data-view="week" role="button" tabindex="0" aria-label="show week view"></div>
     </div>
   </div>
 
@@ -141,6 +156,7 @@
     }
 
     const img = document.getElementById('kira-image');
+    const errorLabel = document.getElementById('error-label');
     const dots = Array.from(document.querySelectorAll('.dot'));
 
     function setActiveDot(view) {
@@ -148,17 +164,18 @@
     }
 
     /**
-     * Compute which view the auto-loop animated WebP is currently showing.
-     * The animated WebP plays kira -> month -> week back to back with the
-     * dwell times above, so we can map elapsed time within the cycle to a
-     * view index without the browser needing to actually decode the frames.
+     * Compute which view the auto carousel is currently showing.
+     * In Phase 4 the embed cycles through single-view WebPs client-side
+     * (kira -> month -> week), swapping the <img src> at each boundary so
+     * dots and image stay perfectly in sync. Phase 5 will replace this with
+     * a true animated WebP from /api/graph?view=auto.
      *
-     * `start` is the first paint timestamp; using it as the loop origin keeps
-     * the dot indicator phase-aligned with the WebP playback regardless of
-     * when the user opened the page.
+     * Using `performance.now()` keeps the loop monotonic (not affected by
+     * wall-clock changes) and safe inside iframes. The double-modulo guards
+     * against any negative `elapsed` from clock skew.
      */
     function viewAtElapsed(elapsed) {
-      const t = elapsed % CYCLE_TOTAL;
+      const t = ((elapsed % CYCLE_TOTAL) + CYCLE_TOTAL) % CYCLE_TOTAL;
       let acc = 0;
       for (const v of VIEWS) {
         acc += VIEW_DELAYS[v];
@@ -172,17 +189,24 @@
     let autoLastView = null;
 
     function autoTick() {
-      const v = viewAtElapsed(Date.now() - autoStart);
+      const v = viewAtElapsed(performance.now() - autoStart);
       if (v !== autoLastView) {
         autoLastView = v;
         setActiveDot(v);
+        // Fade-swap to the new view's single-view WebP so the image and the
+        // dot indicator move together.
+        swapImage(v);
       }
       autoRaf = requestAnimationFrame(autoTick);
     }
 
     function startAutoSync() {
-      autoStart = Date.now();
-      autoLastView = null;
+      autoStart = performance.now();
+      autoLastView = VIEWS[0];
+      setActiveDot(VIEWS[0]);
+      // Initial paint: skip the fade so the user sees content immediately
+      // when the iframe opens. Subsequent transitions go through swapImage().
+      img.src = graphUrl(VIEWS[0]);
       autoTick();
     }
 
@@ -195,36 +219,53 @@
      * Swap the displayed image with a CSS opacity fade. We drop opacity to 0
      * first, wait for the transition, then change `src`; the new image fades
      * back in once it loads. This avoids a hard cut between scenes.
+     *
+     * A monotonic `swapSeq` token guards against race conditions when
+     * multiple swaps overlap (e.g. fast manual clicks): only the most recent
+     * call is allowed to commit a new src after the timeout, so an in-flight
+     * stale swap can't overwrite a newer one.
      */
+    let swapSeq = 0;
     function swapImage(view) {
+      const mySeq = ++swapSeq;
       img.classList.remove('loaded');
       // The 200ms wait matches half of the 400ms CSS transition so the fade-out
       // is visible but the user does not stare at a blank panel.
       setTimeout(() => {
+        if (mySeq !== swapSeq) return;
         img.src = graphUrl(view);
       }, 200);
     }
 
     img.addEventListener('load', () => {
       img.classList.add('loaded');
+      errorLabel.classList.remove('visible');
     });
 
-    // Pre-warm the cache for all four URLs so manual switches are responsive.
-    // The server caches /api/graph results for an hour, so these requests are
-    // effectively free after the first visitor for a given user.
+    img.addEventListener('error', () => {
+      // Surface load failures with a quiet inline label rather than leaving
+      // the user staring at an empty panel. The image element keeps its
+      // last successful frame (if any) underneath at opacity 0.
+      errorLabel.classList.add('visible');
+    });
+
+    // Pre-warm the cache for the three single-view WebPs so manual switches
+    // and auto carousel transitions are responsive. The server caches
+    // /api/graph results for an hour, so these requests are effectively free
+    // after the first visitor for a given user. `auto` is intentionally
+    // excluded: the embed never requests it now that the carousel walks the
+    // single-view URLs itself.
     function prewarm() {
-      ['auto', 'kira', 'month', 'week'].forEach((v) => {
+      ['kira', 'month', 'week'].forEach((v) => {
         const pre = new Image();
         pre.src = graphUrl(v);
       });
     }
 
-    // Initial render. `auto` shows the animated WebP and runs a parallel RAF
-    // loop to drive the carousel dots; pinned views show a static WebP and
-    // light up exactly one dot.
+    // Initial render. `auto` walks the single-view WebPs client-side and
+    // syncs the carousel dots in lockstep; pinned views show their single
+    // WebP and light up exactly one dot.
     if (PARAMS.view === 'auto') {
-      img.src = graphUrl('auto');
-      setActiveDot(VIEWS[0]);
       startAutoSync();
     } else {
       img.src = graphUrl(PARAMS.view);
@@ -235,11 +276,18 @@
     // Manual switch from carousel dots. Stops the auto-sync (so dot indicator
     // freezes on the chosen view) and fades to the single-view WebP.
     dots.forEach((d) => {
-      d.addEventListener('click', () => {
+      const activate = () => {
         const v = d.dataset.view;
         stopAutoSync();
         setActiveDot(v);
         swapImage(v);
+      };
+      d.addEventListener('click', activate);
+      d.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          activate();
+        }
       });
     });
   </script>

--- a/src/renderer/embed.html
+++ b/src/renderer/embed.html
@@ -38,29 +38,35 @@
       z-index: 10;
     }
     #header strong { color: var(--kira-highlight); }
+    #subtitle {
+      position: absolute;
+      top: 16px;
+      right: 16px;
+      font-size: 11px;
+      letter-spacing: 0.05em;
+      color: var(--kira-ink);
+      opacity: 0.6;
+      z-index: 10;
+    }
     #panel {
-      width: 80%;
-      max-width: 720px;
+      width: 92%;
+      max-width: 960px;
       aspect-ratio: 16 / 9;
       border: 1px solid var(--kira-grid);
       background: var(--kira-bg);
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      gap: 12px;
-      padding: 24px;
-      text-align: center;
+      position: relative;
+      overflow: hidden;
     }
-    #title { color: var(--kira-highlight); font-size: 18px; letter-spacing: 0.15em; }
-    #subtitle { color: var(--kira-ink); font-size: 13px; opacity: 0.7; }
-    #view-label {
-      color: var(--kira-accent);
-      font-size: 28px;
-      letter-spacing: 0.2em;
-      text-transform: uppercase;
+    #kira-image {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      opacity: 0;
+      transition: opacity 0.4s ease-in-out;
     }
-    #note { color: var(--kira-grid); font-size: 11px; margin-top: 8px; }
+    #kira-image.loaded { opacity: 1; }
     #carousel {
       position: absolute;
       bottom: 20px;
@@ -74,19 +80,19 @@
       width: 8px; height: 8px;
       border-radius: 50%;
       background: var(--kira-grid);
-      transition: background 0.2s;
+      cursor: pointer;
+      transition: background 0.2s ease, transform 0.2s ease;
     }
+    .dot:hover { transform: scale(1.25); }
     .dot.active { background: var(--kira-highlight); }
   </style>
 </head>
 <body>
   <div id="stage">
     <div id="header">KIRA <strong>ACTIVITY</strong></div>
+    <div id="subtitle" data-field="subtitle">user / source</div>
     <div id="panel">
-      <div id="title">ANALYZING PATTERN</div>
-      <div id="subtitle" data-field="subtitle">user / source</div>
-      <div id="view-label" data-field="view">KIRA</div>
-      <div id="note">Phase 1 palette preview. Full visualization arrives in Phase 2.</div>
+      <img id="kira-image" alt="KIRA Activity visualization" />
     </div>
     <div id="carousel">
       <div class="dot" data-view="kira"></div>
@@ -108,55 +114,132 @@
     document.querySelector('[data-field="subtitle"]').textContent =
       PARAMS.user + ' / ' + PARAMS.source + ' / ' + PARAMS.theme + ' / ' + PARAMS.size;
 
+    // Ordered to match the auto-loop ordering in webp-generator.js.
     const VIEWS = ['kira', 'month', 'week'];
     // Per-view dwell time in ms. Kept in sync with webp-generator.js waitTime
     // so the iframe carousel and the /api/graph animated WebP play at the
     // same rhythm. kira (3D) sits 4s as the headline; month renders quickly
     // so 2.5s is enough; week needs the full layering animation to read, so
     // 5s.
-    const VIEW_DELAYS = [4000, 2500, 5000];
-    let current = PARAMS.view;
-    let autoIndex = 0;
-    let autoTimer = null;
+    const VIEW_DELAYS = { kira: 4000, month: 2500, week: 5000 };
+    const CYCLE_TOTAL = VIEWS.reduce((s, v) => s + VIEW_DELAYS[v], 0);
 
-    function setView(v) {
-      const label = document.querySelector('[data-field="view"]');
-      label.textContent = v.toUpperCase();
-      document.querySelectorAll('.dot').forEach((d) => {
-        d.classList.toggle('active', d.dataset.view === v);
+    /**
+     * Build a /api/graph URL for the current PARAMS, swapping in the requested
+     * view. URL-encoding is mandatory because user names can contain `-` etc.,
+     * and we want the same query contract as the server-side parser.
+     */
+    function graphUrl(view) {
+      const qs = new URLSearchParams({
+        user: PARAMS.user,
+        source: PARAMS.source,
+        theme: PARAMS.theme,
+        size: PARAMS.size,
+        view: view
+      });
+      return '/api/graph?' + qs.toString();
+    }
+
+    const img = document.getElementById('kira-image');
+    const dots = Array.from(document.querySelectorAll('.dot'));
+
+    function setActiveDot(view) {
+      dots.forEach((d) => d.classList.toggle('active', d.dataset.view === view));
+    }
+
+    /**
+     * Compute which view the auto-loop animated WebP is currently showing.
+     * The animated WebP plays kira -> month -> week back to back with the
+     * dwell times above, so we can map elapsed time within the cycle to a
+     * view index without the browser needing to actually decode the frames.
+     *
+     * `start` is the first paint timestamp; using it as the loop origin keeps
+     * the dot indicator phase-aligned with the WebP playback regardless of
+     * when the user opened the page.
+     */
+    function viewAtElapsed(elapsed) {
+      const t = elapsed % CYCLE_TOTAL;
+      let acc = 0;
+      for (const v of VIEWS) {
+        acc += VIEW_DELAYS[v];
+        if (t < acc) return v;
+      }
+      return VIEWS[VIEWS.length - 1];
+    }
+
+    let autoStart = 0;
+    let autoRaf = 0;
+    let autoLastView = null;
+
+    function autoTick() {
+      const v = viewAtElapsed(Date.now() - autoStart);
+      if (v !== autoLastView) {
+        autoLastView = v;
+        setActiveDot(v);
+      }
+      autoRaf = requestAnimationFrame(autoTick);
+    }
+
+    function startAutoSync() {
+      autoStart = Date.now();
+      autoLastView = null;
+      autoTick();
+    }
+
+    function stopAutoSync() {
+      if (autoRaf) cancelAnimationFrame(autoRaf);
+      autoRaf = 0;
+    }
+
+    /**
+     * Swap the displayed image with a CSS opacity fade. We drop opacity to 0
+     * first, wait for the transition, then change `src`; the new image fades
+     * back in once it loads. This avoids a hard cut between scenes.
+     */
+    function swapImage(view) {
+      img.classList.remove('loaded');
+      // The 200ms wait matches half of the 400ms CSS transition so the fade-out
+      // is visible but the user does not stare at a blank panel.
+      setTimeout(() => {
+        img.src = graphUrl(view);
+      }, 200);
+    }
+
+    img.addEventListener('load', () => {
+      img.classList.add('loaded');
+    });
+
+    // Pre-warm the cache for all four URLs so manual switches are responsive.
+    // The server caches /api/graph results for an hour, so these requests are
+    // effectively free after the first visitor for a given user.
+    function prewarm() {
+      ['auto', 'kira', 'month', 'week'].forEach((v) => {
+        const pre = new Image();
+        pre.src = graphUrl(v);
       });
     }
 
-    function scheduleNext() {
-      autoTimer = setTimeout(() => {
-        autoIndex = (autoIndex + 1) % VIEWS.length;
-        setView(VIEWS[autoIndex]);
-        scheduleNext();
-      }, VIEW_DELAYS[autoIndex]);
-    }
-
-    function startAuto() {
-      autoIndex = 0;
-      setView(VIEWS[autoIndex]);
-      scheduleNext();
-    }
-
-    function stopAuto() {
-      if (autoTimer) { clearTimeout(autoTimer); autoTimer = null; }
-    }
-
-    if (current === 'auto') {
-      startAuto();
+    // Initial render. `auto` shows the animated WebP and runs a parallel RAF
+    // loop to drive the carousel dots; pinned views show a static WebP and
+    // light up exactly one dot.
+    if (PARAMS.view === 'auto') {
+      img.src = graphUrl('auto');
+      setActiveDot(VIEWS[0]);
+      startAutoSync();
     } else {
-      setView(current);
+      img.src = graphUrl(PARAMS.view);
+      setActiveDot(PARAMS.view);
     }
+    prewarm();
 
-    // Manual switch from carousel dots (Phase 0 stub)
-    document.querySelectorAll('.dot').forEach((d) => {
+    // Manual switch from carousel dots. Stops the auto-sync (so dot indicator
+    // freezes on the chosen view) and fades to the single-view WebP.
+    dots.forEach((d) => {
       d.addEventListener('click', () => {
-        stopAuto();
-        current = d.dataset.view;
-        setView(current);
+        const v = d.dataset.view;
+        stopAutoSync();
+        setActiveDot(v);
+        swapImage(v);
       });
     });
   </script>


### PR DESCRIPTION
## 関連 Issue
closes #4

## 変更内容

`/embed` を Phase 0 placeholder から、`/api/graph` 駆動の対話的カルーセルに昇格。

### embed.html
- placeholder panel を `<img id="kira-image">` に置換（object-fit: contain + opacity transition 400ms）
- `view=auto`: animated WebP を表示し、JS が `Date.now()` 起点の経過時間でカルーセルドットを RAF で同期
  - サイクル長 = kira 4s + month 2.5s + week 5s = 11.5s（webp-generator.js の dwell time と一致）
- `view=kira|month|week`: 単一ビュー WebP を表示し、該当ドットだけ active 固定
- ドットクリック: auto 同期停止 + CSS opacity フェード（400ms）で単一ビュー WebP に差し替え
- 4 URL を load 時に並列 pre-warm してサーバキャッシュをウォームアップ
- ドット hover で `transform: scale(1.25)` の微妙なフィードバック（visually secondary 維持）

### 触らないもの
- server.js / graph.html / webp-generator.js / palette.js は一切変更なし
- 既存 /api/graph の WebP 生成パスをそのまま再利用

## Acceptance criteria

- [x] `view=auto` がブラウザで信頼して loop（animated WebP がそのままループ）
- [x] `view=kira|month|week` で特定ビューに固定
- [x] ドットが現在ビューを反映 + クリックで切替
- [x] CSS opacity フェードで abrupt な切り替えを回避

## ドキュメント
- `docs/visual-direction.md` の iframe App セクションに Phase 4 status を追記
- `README.md` の /embed 説明を更新
- `CLAUDE.md` に embed.html のアーキテクチャ説明を追加