### PR TITLE
Phase 6: add generic RSS/Atom provider for article-based activity sources (#7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ kira-activity/
 │   ├── services/
 │   │   ├── github.js             # GitHub API クライアント
 │   │   ├── hatena.js             # はてなブックマーク API
+│   │   ├── rss.js                # 汎用 RSS/Atom/RDF フィードクライアント
 │   │   └── cache.js              # キャッシュ管理
 │   ├── renderer/
 │   │   ├── embed.html            # /embed の HTML テンプレート（Phase 0 placeholder）
@@ -63,11 +64,19 @@ kira-activity/
 
 `/embed` と `/api/graph` で同じ仕様。
 
-- `user` (必須)
-- `source` (`github` | `hatena`、default `github`)
+- `user` (必須。`source=rss` のときは表示・キャッシュキー用ラベル)
+- `source` (`github` | `hatena` | `rss`、default `github`)
 - `theme` (`film` | `github` | `hatena` | `sepia` | `mono`、default `film`)
 - `size` (`small` | `medium` | `large`、default `medium`)
 - `view` (`kira` | `month` | `week` | `auto`、default `auto`)
+- `feed` (`source=rss` のとき必須、http(s) URL。それ以外の source では捨てる)
+
+`VALID_SOURCES = { github, hatena, rss }`。`source=rss` は Atom 1.0 / RSS 2.0 / RDF を
+読み、各 entry/item を `{ type:'article', date, title, url }` に正規化して既存の
+data-processor にそのまま流し込む。フィードは直近 10〜50 件しか露出しないことが多い
+ので、week ビューの累積は短期 posting-time bias の表示として読む（長期 edit 活動の
+追跡用ではない）。`feed` の URL ハッシュ（base64url 16 文字）が `/api/graph` の
+キャッシュキーに混ぜられるので、同じ user/source で複数フィードを同時運用しても衝突しない。
 
 公開 API では `step` 語彙を使わない。`step1..step4` は `data-processor.js` の内部キーと
 `graph.html` の内部シーン番号にだけ残る実装詳細。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,19 +64,51 @@ kira-activity/
 
 `/embed` と `/api/graph` で同じ仕様。
 
-- `user` (必須。`source=rss` のときは表示・キャッシュキー用ラベル)
+- `user` (必須。`source=rss` のときは表示用ラベル)
 - `source` (`github` | `hatena` | `rss`、default `github`)
 - `theme` (`film` | `github` | `hatena` | `sepia` | `mono`、default `film`)
 - `size` (`small` | `medium` | `large`、default `medium`)
 - `view` (`kira` | `month` | `week` | `auto`、default `auto`)
-- `feed` (`source=rss` のとき必須、http(s) URL。それ以外の source では捨てる)
+- `feed` (`source=rss` のとき必須、http(s) URL、最大 1024 文字。それ以外の source では捨てる)
 
 `VALID_SOURCES = { github, hatena, rss }`。`source=rss` は Atom 1.0 / RSS 2.0 / RDF を
 読み、各 entry/item を `{ type:'article', date, title, url }` に正規化して既存の
 data-processor にそのまま流し込む。フィードは直近 10〜50 件しか露出しないことが多い
 ので、week ビューの累積は短期 posting-time bias の表示として読む（長期 edit 活動の
-追跡用ではない）。`feed` の URL ハッシュ（base64url 16 文字）が `/api/graph` の
-キャッシュキーに混ぜられるので、同じ user/source で複数フィードを同時運用しても衝突しない。
+追跡用ではない）。
+
+#### `user` パターンの分岐
+
+`source=github` / `source=hatena` の `user` は外部 API に渡るので
+`USER_PATTERN_GH_LIKE = /^[A-Za-z0-9_-]{1,39}$/` に固定する。`source=rss` の `user` は
+表示用ラベルにしか使わず、外部 API には行かないので、Unicode の文字 / 数字 / 句読点 /
+空白を許容する `USER_PATTERN_LABEL = /^[\p{L}\p{N}\p{P}\s_-]{1,64}$/u` に切り替える。
+XSS は既存の `JSON.stringify(...).replace(/</g, '\\u003c')` 注入パターンが守る。
+
+#### `source=rss` のキャッシュキー
+
+`source=github` / `source=hatena` のキャッシュキーは `graph_{source}_{user}_{theme}_{size}_{view}`。
+`source=rss` は `feed` URL が一次キーで `user` は表示ラベルなので、キャッシュキーから
+`user` を除外して `graph_rss_{theme}_{size}_{view}_{feedKey}` にする。`feedKey` は
+`feed` の SHA-256 (base64url, 先頭 16 文字 ≈ 96 bit) で衝突リスクを実用上無視できる
+レベルまで下げる。これで同じ feed に対して別ラベルで来たリクエストは同じキャッシュを
+共有し、外部 feed への重複 fetch を抑制できる。
+
+#### `source=rss` のセキュリティ・運用制約
+
+- **SSRF 対策**: `feed` のホストは DNS 解決後、private / loopback / link-local /
+  metadata IP（`localhost` / `127.0.0.0/8` / `10.0.0.0/8` / `172.16.0.0/12` /
+  `192.168.0.0/16` / `169.254.0.0/16` / `0.0.0.0/8` / `::1` / `fc00::/7` /
+  `fe80::/10`）であれば拒否する。`axios` の `beforeRedirect` でリダイレクト先も
+  再検証する。`username` / `password` を含む URL も拒否
+- **XXE 対策**: 取得した body の先頭 4 KB に `<!DOCTYPE` / `<!ENTITY` が含まれていたら
+  xml2js に渡す前に reject する（billion-laughs / 外部実体展開対策）
+- **URL 長制限**: `feed` は 1024 文字以内（Cloudflare 等の CDN 長さ制限を考慮）
+- **in-flight dedup**: `/embed` の 3 ビュー pre-warm が同じ feed に対して 3 連射しても、
+  webp-generator の module-level `inFlightFeeds: Map<feedUrl, Promise>` が単一の
+  Promise を共有するので fetch は 1 回に集約される
+- **エラー応答**: `source=rss` 経路の 500 は `details: 'feed fetch failed'` の
+  generic 文言にする（探索性のある details の露出を防ぐ）
 
 公開 API では `step` 語彙を使わない。`step1..step4` は `data-processor.js` の内部キーと
 `graph.html` の内部シーン番号にだけ残る実装詳細。

--- a/README.md
+++ b/README.md
@@ -53,11 +53,20 @@ swap し、下部のカルーセルドットと画像を完全同期させる。
 
 | パラメータ | 値 | デフォルト | 説明 |
 |---|---|---|---|
-| `user` | string | （必須） | ユーザー名 |
-| `source` | `github` / `hatena` | `github` | データソース |
+| `user` | string | （必須） | ユーザー名（`source=rss` のときは表示・キャッシュキー用ラベル） |
+| `source` | `github` / `hatena` / `rss` | `github` | データソース |
 | `theme` | `film` / `github` / `hatena` / `sepia` / `mono` | `film` | 配色テーマ |
 | `size` | `small` / `medium` / `large` | `medium` | ビューポートサイズ |
 | `view` | `kira` / `month` / `week` / `auto` | `auto` | 表示モード |
+| `feed` | http(s) URL | — | `source=rss` のときのみ必須。Atom 1.0 / RSS 2.0 / RDF を受け付ける |
+
+#### `source=rss` の限界
+
+任意のブログ・サービスの RSS/Atom フィードを `source=rss&feed=URL` で読ませると、
+記事の publish 時刻を「活動イベント」として可視化する。ただし多くのサービスは
+フィードに直近 10〜50 件しか含めず、長期 edit 履歴は手に入らない。week ビューの
+週次累積は当然この範囲しか積めないので、長期の繰り返し bias 解析というよりは
+**直近の posting-time bias** の俯瞰として読むのが妥当。
 
 ### ビュー
 
@@ -86,6 +95,7 @@ swap し、下部のカルーセルドットと画像を完全同期させる。
 - `/api/graph?user=torvalds&view=week&theme=film&size=large` — 単一ビューの WebP
 - `/api/graph?user=torvalds&source=github&theme=film` — film 配色 + GitHub 緑のアクセント
 - `/api/graph?user=torvalds&source=hatena&theme=film` — film 配色 + はてな青のアクセント
+- `/api/graph?user=foo&source=rss&feed=https%3A%2F%2Fexample.com%2Fatom` — 任意フィードの記事公開時刻を可視化
 
 ## 技術スタック
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,29 @@ swap し、下部のカルーセルドットと画像を完全同期させる。
 | `theme` | `film` / `github` / `hatena` / `sepia` / `mono` | `film` | 配色テーマ |
 | `size` | `small` / `medium` / `large` | `medium` | ビューポートサイズ |
 | `view` | `kira` / `month` / `week` / `auto` | `auto` | 表示モード |
-| `feed` | http(s) URL | — | `source=rss` のときのみ必須。Atom 1.0 / RSS 2.0 / RDF を受け付ける |
+| `feed` | http(s) URL（最大 1024 文字） | — | `source=rss` のときのみ必須。Atom 1.0 / RSS 2.0 / RDF を受け付ける |
+
+#### `source=rss` の `user` パラメータ
+
+`source=github` / `source=hatena` の `user` は外部 API に渡るので
+`/^[A-Za-z0-9_-]{1,39}$/`（GitHub ユーザー名仕様）に固定。
+`source=rss` の `user` は表示用ラベルでしかなく、外部に投げないので Unicode の
+文字 / 数字 / 句読点 / 空白を含む最大 64 文字のラベルを許容する。
+`source=rss` ではキャッシュキーから `user` を除外し、同じ feed なら user を変えても
+同じ画像を返す（外部 feed への重複 fetch を抑制）。
+
+#### `source=rss` のセキュリティ制約
+
+- `feed` ホストはパブリック IP に解決されるものに限る。`localhost` /
+  `127.0.0.0/8` / `10.0.0.0/8` / `172.16.0.0/12` / `192.168.0.0/16` /
+  `169.254.0.0/16`（リンクローカル / クラウドメタデータ）/ `0.0.0.0/8` /
+  `::1` / `fc00::/7` / `fe80::/10` は **接続不可**（SSRF 対策）
+- リダイレクト先も同じルールで再検証する
+- ユーザー情報入り URL（`https://user:pass@example.com/...`）は拒否
+- フィード本文に `<!DOCTYPE>` / `<!ENTITY>` 宣言が含まれていたら拒否
+  （billion-laughs / 外部実体展開対策）
+- フェッチサイズ上限は 5 MB
+- 失敗時のエラー詳細は `feed fetch failed` の generic 表記に丸める
 
 #### `source=rss` の限界
 

--- a/docs/visual-direction.md
+++ b/docs/visual-direction.md
@@ -219,6 +219,20 @@ iframe 用 UI:
 - JSON 入力
 - 他サービス入力
 
+> **Phase 6 status:** 「他サービス入力」のうち RSS/Atom/RDF 系は実装済み。
+> `source=rss&feed=URL` で任意のフィードを読み、各 entry/item を
+> `{ type:'article', date, title, url }` に正規化して既存の data-processor に
+> そのまま流し込む。Atom は `published > updated`、RSS 2.0 は
+> `pubDate > dc:date`、RDF は `dc:date > pubDate` の優先順で日付を抽出する。
+> 視覚化レイヤー（graph.html / data-processor.js）にソース固有ロジックは入っていない。
+>
+> **Limitation:** ほとんどのサービスはフィードに直近 10〜50 件しか含めない。
+> week ビューの累積は当然この範囲に閉じるため、長期の繰り返し bias を読むツール
+> ではなく、**直近の posting-time bias を眺めるツール**として捉えるのが正しい。
+> `feed` の URL ハッシュ（base64url 16 文字）を `/api/graph` のキャッシュキーに
+> 混ぜているので、同じ user/source で複数フィードを同時運用しても衝突しない。
+> カスタム配色 / JSON 入力は Phase 6 のスコープ外。
+
 ## Rendering Notes
 
 `/api/graph` は Phase 5 で真の animated WebP に対応済み。`view=auto`（デフォルト）は

--- a/docs/visual-direction.md
+++ b/docs/visual-direction.md
@@ -229,9 +229,15 @@ iframe 用 UI:
 > **Limitation:** ほとんどのサービスはフィードに直近 10〜50 件しか含めない。
 > week ビューの累積は当然この範囲に閉じるため、長期の繰り返し bias を読むツール
 > ではなく、**直近の posting-time bias を眺めるツール**として捉えるのが正しい。
-> `feed` の URL ハッシュ（base64url 16 文字）を `/api/graph` のキャッシュキーに
-> 混ぜているので、同じ user/source で複数フィードを同時運用しても衝突しない。
+> `feed` の SHA-256 ハッシュ（base64url 先頭 16 文字）を `/api/graph` のキャッシュキー
+> に使い、`source=rss` ではキャッシュキーから `user`（表示ラベル）を除外する。
 > カスタム配色 / JSON 入力は Phase 6 のスコープ外。
+>
+> **Security:** `source=rss` の `feed` は private / loopback / link-local /
+> metadata IP に解決されるホストへの接続を拒否（SSRF 対策）し、リダイレクト先も
+> 再検証する。`<!DOCTYPE>` / `<!ENTITY>` を含む body は xml2js に渡す前に reject
+> する（XXE / billion-laughs 対策）。URL 長は 1024 文字、フェッチサイズは 5 MB
+> 上限。`/embed` の 3 ビュー pre-warm は in-flight Map で 1 fetch に集約。
 
 ## Rendering Notes
 

--- a/src/renderer/embed.html
+++ b/src/renderer/embed.html
@@ -118,12 +118,16 @@
 
   <script>
     // Server-injected params (placeholders replaced at request time).
+    // `feed` is the absolute URL of an external RSS/Atom/RDF feed. It is a
+    // string only when source === 'rss'; for github/hatena the server
+    // injects null so the client never appends it to /api/graph URLs.
     const PARAMS = {
       user: __USER__,
       source: __SOURCE__,
       theme: __THEME__,
       size: __SIZE__,
-      view: __VIEW__
+      view: __VIEW__,
+      feed: __FEED__
     };
 
     document.querySelector('[data-field="subtitle"]').textContent =
@@ -152,6 +156,9 @@
         size: PARAMS.size,
         view: view
       });
+      // Carry the feed URL through so single-view swaps and pre-warming
+      // hit the same cache entry the server keyed by feed.
+      if (PARAMS.feed) qs.set('feed', PARAMS.feed);
       return '/api/graph?' + qs.toString();
     }
 

--- a/src/renderer/webp-generator.js
+++ b/src/renderer/webp-generator.js
@@ -17,6 +17,13 @@ const githubClient = new GitHubClient();
 const hatenaClient = new HatenaBookmarkClient();
 const rssClient = new RssAtomFeedClient();
 
+// In-flight request deduplication for source=rss. /embed pre-warms three
+// single-view WebPs in parallel, so without dedup we'd fire three identical
+// fetches at the upstream feed within milliseconds. Sharing one Promise
+// keyed by feed URL collapses that to a single fetch; the entry is cleared
+// once the Promise settles so a later cache miss can refetch normally.
+const inFlightFeeds = new Map();
+
 // Singleton browser instance for better performance
 let browserInstance = null;
 
@@ -160,7 +167,23 @@ async function fetchActivityData(username, source, feed) {
     if (!feed) {
       throw new Error('feed URL required for source=rss');
     }
-    return await rssClient.getComprehensiveActivity(feed, username);
+    // Dedupe concurrent fetches against the same feed URL. The first caller
+    // installs a Promise; subsequent callers (e.g. parallel pre-warm of
+    // kira / month / week) await the same Promise. The finally clears the
+    // entry so cache misses after this batch can fetch fresh.
+    const existing = inFlightFeeds.get(feed);
+    if (existing) {
+      return await existing;
+    }
+    const promise = (async () => {
+      try {
+        return await rssClient.getComprehensiveActivity(feed, username);
+      } finally {
+        inFlightFeeds.delete(feed);
+      }
+    })();
+    inFlightFeeds.set(feed, promise);
+    return await promise;
   }
   throw new Error(`Unknown source: ${source}`);
 }

--- a/src/renderer/webp-generator.js
+++ b/src/renderer/webp-generator.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { GitHubClient } from '../services/github.js';
 import { HatenaBookmarkClient } from '../services/hatena.js';
+import { RssAtomFeedClient } from '../services/rss.js';
 import { DataProcessor } from '../utils/data-processor.js';
 import { getPalette, sanitizePalette } from './palette.js';
 
@@ -14,6 +15,7 @@ const __dirname = dirname(__filename);
 
 const githubClient = new GitHubClient();
 const hatenaClient = new HatenaBookmarkClient();
+const rssClient = new RssAtomFeedClient();
 
 // Singleton browser instance for better performance
 let browserInstance = null;
@@ -68,14 +70,15 @@ async function getBrowser() {
  *   ('film' | 'github' | 'hatena' | 'sepia' | 'mono')。それ以外は film にフォールバック。
  * @param {string} size - 'small' | 'medium' | 'large'
  * @param {object} [palette] - Resolved palette from server. If omitted, resolved here.
+ * @param {string} [feed] - Feed URL when source='rss'. Ignored otherwise.
  * @returns {Promise<Buffer>} WebP buffer
  */
-export async function generateAnimatedWebP(username, source, theme, size, palette) {
+export async function generateAnimatedWebP(username, source, theme, size, palette, feed) {
   console.log(`Generating animated WebP for ${username} (${source}, theme=${theme})...`);
 
   const resolvedPalette = sanitizePalette(palette ?? getPalette(theme, source));
 
-  const activityData = await fetchActivityData(username, source);
+  const activityData = await fetchActivityData(username, source, feed);
   const processedData = DataProcessor.process(activityData);
 
   console.log('Rendering all views in parallel...');
@@ -112,9 +115,10 @@ export async function generateAnimatedWebP(username, source, theme, size, palett
  *   ('film' | 'github' | 'hatena' | 'sepia' | 'mono')。それ以外は film にフォールバック。
  * @param {string} size
  * @param {object} [palette] - Resolved palette from server. If omitted, resolved here.
+ * @param {string} [feed] - Feed URL when source='rss'. Ignored otherwise.
  * @returns {Promise<Buffer>} WebP buffer
  */
-export async function generateView(username, source, view, theme, size, palette) {
+export async function generateView(username, source, view, theme, size, palette, feed) {
   const scene = VIEW_TO_SCENE[view];
   if (!scene) {
     throw new Error(`Unknown view: ${view}`);
@@ -124,7 +128,7 @@ export async function generateView(username, source, view, theme, size, palette)
 
   const resolvedPalette = sanitizePalette(palette ?? getPalette(theme, source));
 
-  const activityData = await fetchActivityData(username, source);
+  const activityData = await fetchActivityData(username, source, feed);
   const processedData = DataProcessor.process(activityData);
 
   const frame = await renderScene(processedData, scene, theme, size, resolvedPalette);
@@ -138,18 +142,27 @@ export async function generateView(username, source, view, theme, size, palette)
 }
 
 /**
- * Fetch activity data from source
+ * Fetch activity data from source.
+ * For source='rss', the `feed` URL is required and is used both for the
+ * actual fetch and as the implicit identity (the `username` becomes a
+ * display label only).
  */
-async function fetchActivityData(username, source) {
+async function fetchActivityData(username, source, feed) {
   console.log(`Fetching ${source} data for ${username}...`);
 
   if (source === 'github') {
     return await githubClient.getComprehensiveActivity(username);
-  } else if (source === 'hatena') {
-    return await hatenaClient.getComprehensiveActivity(username);
-  } else {
-    throw new Error(`Unknown source: ${source}`);
   }
+  if (source === 'hatena') {
+    return await hatenaClient.getComprehensiveActivity(username);
+  }
+  if (source === 'rss') {
+    if (!feed) {
+      throw new Error('feed URL required for source=rss');
+    }
+    return await rssClient.getComprehensiveActivity(feed, username);
+  }
+  throw new Error(`Unknown source: ${source}`);
 }
 
 /**

--- a/src/server.js
+++ b/src/server.js
@@ -17,13 +17,17 @@ const PORT = Number(process.env.PORT) || 3000;
 const cache = new CacheManager();
 
 // Shared query param contract
-const VALID_SOURCES = new Set(['github', 'hatena']);
+const VALID_SOURCES = new Set(['github', 'hatena', 'rss']);
 const VALID_THEMES = new Set(PALETTE_THEMES);
 const VALID_SIZES = new Set(['small', 'medium', 'large']);
 const VALID_VIEWS = new Set(['kira', 'month', 'week', 'auto']);
 // GitHub username spec: 1-39 chars, alphanumerics and hyphens.
 // We accept underscore too for forward compatibility with hatena IDs.
 const USER_PATTERN = /^[A-Za-z0-9_-]{1,39}$/;
+// `feed` is a fully qualified http/https URL. We only enforce a coarse shape
+// here (scheme + non-whitespace + length cap) because the client-side fetcher
+// in services/rss.js will fail loudly on actual network/parse errors.
+const FEED_URL_PATTERN = /^https?:\/\/[^\s]{1,2048}$/i;
 
 function parseSharedParams(c) {
   const user = c.req.query('user');
@@ -31,6 +35,7 @@ function parseSharedParams(c) {
   const theme = c.req.query('theme') || 'film';
   const size = c.req.query('size') || 'medium';
   const view = c.req.query('view') || 'auto';
+  const rawFeed = (c.req.query('feed') || '').trim();
 
   if (!user) {
     return { error: 'user parameter is required' };
@@ -51,11 +56,27 @@ function parseSharedParams(c) {
     return { error: `invalid view: ${view}` };
   }
 
+  // `feed` is required when source=rss and ignored otherwise. We discard it
+  // for non-rss sources so it does not pollute the cache key (or accidentally
+  // feed into a future provider that hasn't opted in to it yet).
+  let feed;
+  if (source === 'rss') {
+    if (!rawFeed) {
+      return { error: 'feed parameter is required when source=rss' };
+    }
+    if (!FEED_URL_PATTERN.test(rawFeed)) {
+      return { error: 'invalid feed: must be an http(s) URL' };
+    }
+    feed = rawFeed;
+  } else {
+    feed = undefined;
+  }
+
   // Resolve palette once per request and pass it down. Sanitized so any
   // accidental non-hex value is replaced before it reaches CSS injection.
   const palette = sanitizePalette(getPalette(theme, source));
 
-  return { user, source, theme, size, view, palette };
+  return { user, source, theme, size, view, palette, feed };
 }
 
 // Eager load template at module init. Failing fast at startup is preferable
@@ -85,7 +106,9 @@ function renderEmbed(params) {
     SOURCE: params.source,
     THEME: params.theme,
     SIZE: params.size,
-    VIEW: params.view
+    VIEW: params.view,
+    // null when source != rss so the embed JS can skip appending &feed=.
+    FEED: params.feed ?? null
   };
   const cssMap = {
     PALETTE_BG: params.palette.background,
@@ -95,7 +118,7 @@ function renderEmbed(params) {
     PALETTE_HIGHLIGHT: params.palette.highlight
   };
   return EMBED_TEMPLATE.replace(
-    /__(USER|SOURCE|THEME|SIZE|VIEW|PALETTE_BG|PALETTE_INK|PALETTE_GRID|PALETTE_ACCENT|PALETTE_HIGHLIGHT)__/g,
+    /__(USER|SOURCE|THEME|SIZE|VIEW|FEED|PALETTE_BG|PALETTE_INK|PALETTE_GRID|PALETTE_ACCENT|PALETTE_HIGHLIGHT)__/g,
     (_, k) => {
       if (k in cssMap) return cssMap[k];
       return JSON.stringify(scriptMap[k]).replace(/</g, '\\u003c');
@@ -137,10 +160,16 @@ app.get('/api/graph', async (c) => {
     return c.json({ error: params.error }, 400);
   }
 
-  const { user, source, theme, size, view, palette } = params;
+  const { user, source, theme, size, view, palette, feed } = params;
 
   try {
-    const cacheKey = `graph_${source}_${user}_${theme}_${size}_${view}`;
+    // Encode the feed URL into a short stable suffix so two different feeds
+    // for the same source=rss don't collide in cache. base64url is safe for
+    // a cache key (no '/', '+', '='). Truncating to 16 chars keeps the key
+    // compact at the cost of a ~10^-9 collision risk per user, which is
+    // acceptable for a 1-hour cached image.
+    const feedKey = feed ? `_${Buffer.from(feed).toString('base64url').slice(0, 16)}` : '';
+    const cacheKey = `graph_${source}_${user}_${theme}_${size}_${view}${feedKey}`;
     const cached = cache.get(cacheKey);
     if (cached) {
       return new Response(cached, {
@@ -152,8 +181,8 @@ app.get('/api/graph', async (c) => {
     }
 
     const webpBuffer = view === 'auto'
-      ? await generateAnimatedWebP(user, source, theme, size, palette)
-      : await generateView(user, source, view, theme, size, palette);
+      ? await generateAnimatedWebP(user, source, theme, size, palette, feed)
+      : await generateView(user, source, view, theme, size, palette, feed);
 
     cache.set(cacheKey, webpBuffer);
 

--- a/src/server.js
+++ b/src/server.js
@@ -35,7 +35,9 @@ const USER_PATTERN_LABEL = /^[\p{L}\p{N}\p{P}\s_-]{1,64}$/u;
 // than RFC's de-facto 2048: Cloudflare and most CDNs reject URLs longer
 // than that for cached endpoints, and a feed URL that doesn't fit is a
 // strong signal of abuse.
-const FEED_URL_PATTERN = /^https?:\/\/[^\s]{1,1024}$/i;
+// `[^\s]{1,1016}` after `https?://` (max 8 chars) keeps the total URL <= 1024
+// chars, matching the documented 1 KB cap.
+const FEED_URL_PATTERN = /^https?:\/\/[^\s]{1,1016}$/i;
 
 function parseSharedParams(c) {
   const user = c.req.query('user');

--- a/src/server.js
+++ b/src/server.js
@@ -4,6 +4,7 @@ import dotenv from 'dotenv';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { createHash } from 'crypto';
 import { generateAnimatedWebP, generateView, shutdown as shutdownRenderer } from './renderer/webp-generator.js';
 import { getPalette, sanitizePalette, VALID_THEMES as PALETTE_THEMES } from './renderer/palette.js';
 import { CacheManager } from './services/cache.js';
@@ -23,11 +24,18 @@ const VALID_SIZES = new Set(['small', 'medium', 'large']);
 const VALID_VIEWS = new Set(['kira', 'month', 'week', 'auto']);
 // GitHub username spec: 1-39 chars, alphanumerics and hyphens.
 // We accept underscore too for forward compatibility with hatena IDs.
-const USER_PATTERN = /^[A-Za-z0-9_-]{1,39}$/;
-// `feed` is a fully qualified http/https URL. We only enforce a coarse shape
-// here (scheme + non-whitespace + length cap) because the client-side fetcher
-// in services/rss.js will fail loudly on actual network/parse errors.
-const FEED_URL_PATTERN = /^https?:\/\/[^\s]{1,2048}$/i;
+const USER_PATTERN_GH_LIKE = /^[A-Za-z0-9_-]{1,39}$/;
+// For source=rss the `user` parameter is a display/cache label only — it
+// never round-trips to an external API — so we accept any reasonable
+// printable string (letters / digits / punctuation / spaces, ≤64 chars).
+// XSS is already prevented by the JSON-encoded + `<` escaped injection in
+// renderEmbed() / webp-generator.js.
+const USER_PATTERN_LABEL = /^[\p{L}\p{N}\p{P}\s_-]{1,64}$/u;
+// `feed` is a fully qualified http/https URL. The 1024-char cap is tighter
+// than RFC's de-facto 2048: Cloudflare and most CDNs reject URLs longer
+// than that for cached endpoints, and a feed URL that doesn't fit is a
+// strong signal of abuse.
+const FEED_URL_PATTERN = /^https?:\/\/[^\s]{1,1024}$/i;
 
 function parseSharedParams(c) {
   const user = c.req.query('user');
@@ -40,11 +48,14 @@ function parseSharedParams(c) {
   if (!user) {
     return { error: 'user parameter is required' };
   }
-  if (!USER_PATTERN.test(user)) {
-    return { error: 'invalid user: must match /^[A-Za-z0-9_-]{1,39}$/' };
-  }
   if (!VALID_SOURCES.has(source)) {
     return { error: `invalid source: ${source}` };
+  }
+  // user pattern depends on source: github/hatena need API-safe handles,
+  // rss only uses the value as a label so we accept a wider character set.
+  const userPattern = source === 'rss' ? USER_PATTERN_LABEL : USER_PATTERN_GH_LIKE;
+  if (!userPattern.test(user)) {
+    return { error: `invalid user: does not match the pattern allowed for source=${source}` };
   }
   if (!VALID_THEMES.has(theme)) {
     return { error: `invalid theme: ${theme}` };
@@ -164,12 +175,20 @@ app.get('/api/graph', async (c) => {
 
   try {
     // Encode the feed URL into a short stable suffix so two different feeds
-    // for the same source=rss don't collide in cache. base64url is safe for
-    // a cache key (no '/', '+', '='). Truncating to 16 chars keeps the key
-    // compact at the cost of a ~10^-9 collision risk per user, which is
-    // acceptable for a 1-hour cached image.
-    const feedKey = feed ? `_${Buffer.from(feed).toString('base64url').slice(0, 16)}` : '';
-    const cacheKey = `graph_${source}_${user}_${theme}_${size}_${view}${feedKey}`;
+    // for the same source=rss don't collide in cache. SHA-256 (base64url,
+    // first 16 chars ≈ 96 bits of entropy) avoids the trivial reversibility
+    // of raw base64 and gives effectively zero collision risk for cached
+    // images.
+    const feedKey = feed
+      ? `_${createHash('sha256').update(feed).digest('base64url').slice(0, 16)}`
+      : '';
+    // For source=rss the `feed` URL is the actual data identity; `user` is
+    // only a display label, so we leave it out of the cache key. This lets
+    // multiple labels share one cached fetch and prevents trivial cache
+    // pollution by varying `user` against the same feed.
+    const cacheKey = source === 'rss'
+      ? `graph_rss_${theme}_${size}_${view}${feedKey}`
+      : `graph_${source}_${user}_${theme}_${size}_${view}`;
     const cached = cache.get(cacheKey);
     if (cached) {
       return new Response(cached, {
@@ -194,7 +213,12 @@ app.get('/api/graph', async (c) => {
     });
   } catch (error) {
     console.error('Error generating graph:', error);
-    return c.json({ error: 'Failed to generate graph', details: error.message }, 500);
+    // For source=rss we deliberately return a generic message so a malformed
+    // / malicious URL or upstream HTTP error doesn't echo back details that
+    // help probe internal infrastructure. github / hatena keep the original
+    // surface since their failure modes are well-known public APIs.
+    const details = source === 'rss' ? 'feed fetch failed' : error.message;
+    return c.json({ error: 'Failed to generate graph', details }, 500);
   }
 });
 

--- a/src/services/rss.js
+++ b/src/services/rss.js
@@ -1,0 +1,171 @@
+import axios from 'axios';
+import { parseStringPromise } from 'xml2js';
+
+const FEED_FETCH_TIMEOUT_MS = 15000;
+const FEED_USER_AGENT = 'kira-activity/1.0 (+https://github.com/kako-jun/kira-activity)';
+const FEED_MAX_BYTES = 5 * 1024 * 1024; // 5 MB
+
+/**
+ * Generic RSS/Atom/RDF feed client.
+ *
+ * Normalizes any compliant feed into the common
+ * `{ events: [{ date, type, title, url }] }` shape used by visualization.
+ * Supports:
+ *   - Atom 1.0 (parsed.feed)
+ *   - RSS 2.0 (parsed.rss.channel)
+ *   - RSS 1.0 / RDF (parsed['rdf:RDF'])
+ *
+ * Date extraction tries multiple fields in order:
+ *   Atom:   entry.published > entry.updated
+ *   RSS 2:  item.pubDate > item['dc:date']
+ *   RDF:    item['dc:date'] > item.pubDate
+ *
+ * Feeds typically expose only the most recent 10-50 entries, so the
+ * resulting visualization only shows posting-time bias for the recent
+ * window — not long-tail edit history.
+ */
+export class RssAtomFeedClient {
+  /**
+   * Fetch a feed URL and return normalized event objects.
+   * @param {string} feedUrl - Absolute http/https URL of the feed
+   * @returns {Promise<Array<{type:string,date:string,title:string,url:string}>>}
+   */
+  async fetchEvents(feedUrl) {
+    if (!/^https?:\/\//i.test(feedUrl)) {
+      throw new Error(`Invalid feed URL: ${feedUrl}`);
+    }
+    const response = await axios.get(feedUrl, {
+      timeout: FEED_FETCH_TIMEOUT_MS,
+      maxContentLength: FEED_MAX_BYTES,
+      // Many servers return the feed body differently if axios sends
+      // `Accept: application/json,*/*` (the default). Restrict to feed-ish
+      // content types and identify ourselves so the request is debuggable.
+      headers: {
+        'User-Agent': FEED_USER_AGENT,
+        'Accept': 'application/rss+xml, application/atom+xml, application/xml, text/xml'
+      },
+      // Treat non-2xx as errors (axios default), but propagate the message
+      // so the caller can surface it in the JSON error response.
+      responseType: 'text'
+    });
+    const parsed = await parseStringPromise(response.data, {
+      explicitArray: false,
+      ignoreAttrs: false
+    });
+    return this.normalize(parsed);
+  }
+
+  /**
+   * Dispatch to a format-specific normalizer based on the parsed root.
+   * Throws if the document is not a recognized feed shape.
+   */
+  normalize(parsed) {
+    if (parsed.feed) return this.normalizeAtom(parsed.feed);
+    if (parsed.rss?.channel) return this.normalizeRss20(parsed.rss.channel);
+    if (parsed['rdf:RDF']) return this.normalizeRdf(parsed['rdf:RDF']);
+    throw new Error('Unrecognized feed format (expected Atom, RSS 2.0, or RDF)');
+  }
+
+  normalizeAtom(feed) {
+    const entries = this.toArray(feed.entry);
+    return entries
+      .map((entry) => ({
+        type: 'article',
+        date: this.pickDate(entry.published, entry.updated),
+        title: this.text(entry.title) || 'No title',
+        url: this.atomLink(entry.link) || ''
+      }))
+      .filter((e) => e.date);
+  }
+
+  normalizeRss20(channel) {
+    const items = this.toArray(channel.item);
+    return items
+      .map((item) => ({
+        type: 'article',
+        date: this.pickDate(item.pubDate, item['dc:date']),
+        title: this.text(item.title) || 'No title',
+        url: this.text(item.link) || ''
+      }))
+      .filter((e) => e.date);
+  }
+
+  normalizeRdf(rdf) {
+    const items = this.toArray(rdf.item);
+    return items
+      .map((item) => ({
+        type: 'article',
+        date: this.pickDate(item['dc:date'], item.pubDate),
+        title: this.text(item.title) || 'No title',
+        url: this.text(item.link) || ''
+      }))
+      .filter((e) => e.date);
+  }
+
+  /** Coerce xml2js single-or-many output into an array (empty for null/undefined). */
+  toArray(v) {
+    if (v == null) return [];
+    return Array.isArray(v) ? v : [v];
+  }
+
+  /**
+   * Extract text content from an xml2js node.
+   * xml2js with `ignoreAttrs: false` collapses simple text into a string,
+   * but a node with attributes becomes `{ _: 'text', $: { ... } }`.
+   */
+  text(v) {
+    if (v == null) return '';
+    if (typeof v === 'string') return v;
+    if (typeof v === 'object' && '_' in v) return v._;
+    return String(v);
+  }
+
+  /**
+   * Try each candidate as a date string and return the first one that parses.
+   * Returns an ISO 8601 string in UTC, or `null` if none parsed.
+   */
+  pickDate(...candidates) {
+    for (const c of candidates) {
+      if (!c) continue;
+      const s = this.text(c);
+      if (!s) continue;
+      const d = new Date(s);
+      if (!isNaN(d.getTime())) return d.toISOString();
+    }
+    return null;
+  }
+
+  /**
+   * Atom <link> can be a single object, an array, or a plain string.
+   * Prefer rel="alternate" (canonical entry URL); fall back to the first
+   * link with no rel; then any href; then the bare string form.
+   */
+  atomLink(linkField) {
+    if (!linkField) return '';
+    const links = this.toArray(linkField);
+    const preferred = links.find((l) => l?.$ && (l.$.rel === 'alternate' || !l.$.rel));
+    if (preferred?.$?.href) return preferred.$.href;
+    if (links[0]?.$?.href) return links[0].$.href;
+    if (typeof links[0] === 'string') return links[0];
+    return '';
+  }
+
+  /**
+   * Match the shape returned by GitHubClient / HatenaBookmarkClient so
+   * downstream `data-processor.js` does not need source-specific logic.
+   *
+   * @param {string} feedUrl - Absolute http/https URL of the feed
+   * @param {string} [username] - Display/cache label. Defaults to `feedUrl`.
+   * @returns {Promise<{username:string,totalActivity:number,events:Array,fetchedAt:string}>}
+   */
+  async getComprehensiveActivity(feedUrl, username) {
+    const events = await this.fetchEvents(feedUrl);
+    events.sort((a, b) => new Date(b.date) - new Date(a.date));
+    return {
+      username: username || feedUrl,
+      totalActivity: events.length,
+      events,
+      fetchedAt: new Date().toISOString()
+    };
+  }
+}

--- a/src/services/rss.js
+++ b/src/services/rss.js
@@ -1,9 +1,71 @@
 import axios from 'axios';
 import { parseStringPromise } from 'xml2js';
+import { lookup } from 'dns/promises';
 
 const FEED_FETCH_TIMEOUT_MS = 15000;
 const FEED_USER_AGENT = 'kira-activity/1.0 (+https://github.com/kako-jun/kira-activity)';
 const FEED_MAX_BYTES = 5 * 1024 * 1024; // 5 MB
+
+// Atom <link> rel values we accept as the canonical entry URL.
+// undefined / '' covers `<link href="...">` with no rel attribute.
+const ALLOWED_LINK_RELS = new Set(['alternate', '', undefined]);
+
+/**
+ * Reject hostnames that resolve to private / loopback / link-local IPs.
+ * This is the first line of SSRF defense for `source=rss`: even if the URL
+ * passes scheme + length validation upstream, we don't want feed fetches to
+ * land on internal services or cloud metadata endpoints (169.254.169.254).
+ *
+ * Notes / known limitations:
+ *   - DNS rebinding is not fully prevented here; an attacker controlling DNS
+ *     could return a public IP at validation time and a private IP at fetch
+ *     time. Mitigating that fully requires resolving the IP once and
+ *     connecting directly to that IP (custom http agent), which adds
+ *     complexity. We accept the residual risk for now and rely on this
+ *     coarse filter + Node's default agent.
+ *   - String guards for `localhost` and `*.local` catch the common cases
+ *     before DNS resolution.
+ */
+async function isPrivateHost(hostname) {
+  if (/^(localhost|.*\.local)$/i.test(hostname)) return true;
+
+  let ip;
+  try {
+    const result = await lookup(hostname);
+    ip = result.address;
+  } catch {
+    // Unresolvable hostnames are rejected: we don't want to fall through to
+    // axios where the failure mode could vary by environment.
+    return true;
+  }
+  return isPrivateIp(ip);
+}
+
+/**
+ * CIDR-style check for IPv4 / IPv6 ranges that should never be reachable
+ * from a feed fetcher: loopback, link-local, RFC1918, IPv6 ULA / link-local,
+ * and the unspecified 0.0.0.0/8 block.
+ */
+function isPrivateIp(ip) {
+  // IPv4
+  const v4 = ip.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  if (v4) {
+    const [, a, b] = v4.map(Number);
+    if (a === 10) return true;                         // 10.0.0.0/8
+    if (a === 127) return true;                        // 127.0.0.0/8 loopback
+    if (a === 0) return true;                          // 0.0.0.0/8
+    if (a === 169 && b === 254) return true;           // 169.254.0.0/16 link-local / metadata
+    if (a === 172 && b >= 16 && b <= 31) return true;  // 172.16.0.0/12
+    if (a === 192 && b === 168) return true;           // 192.168.0.0/16
+    return false;
+  }
+  // IPv6
+  const v6 = ip.toLowerCase();
+  if (v6 === '::1' || v6 === '::') return true;
+  if (v6.startsWith('fe80:')) return true;             // fe80::/10 link-local
+  if (v6.startsWith('fc') || v6.startsWith('fd')) return true; // fc00::/7 ULA
+  return false;
+}
 
 /**
  * Generic RSS/Atom/RDF feed client.
@@ -23,6 +85,12 @@ const FEED_MAX_BYTES = 5 * 1024 * 1024; // 5 MB
  * Feeds typically expose only the most recent 10-50 entries, so the
  * resulting visualization only shows posting-time bias for the recent
  * window — not long-tail edit history.
+ *
+ * Security: SSRF / XXE / credential-leak hardened. Hostnames resolving to
+ * private / link-local / loopback IPs are rejected, URLs containing
+ * userinfo (user:pass@) are rejected, and feed bodies that contain XML
+ * `<!DOCTYPE>` / `<!ENTITY>` declarations are rejected before being fed
+ * to xml2js to prevent billion-laughs / external entity expansion.
  */
 export class RssAtomFeedClient {
   /**
@@ -32,11 +100,26 @@ export class RssAtomFeedClient {
    */
   async fetchEvents(feedUrl) {
     if (!/^https?:\/\//i.test(feedUrl)) {
-      throw new Error(`Invalid feed URL: ${feedUrl}`);
+      throw new Error('invalid feed URL: scheme must be http or https');
     }
+
+    let parsedUrl;
+    try {
+      parsedUrl = new URL(feedUrl);
+    } catch {
+      throw new Error('invalid feed URL');
+    }
+    if (parsedUrl.username || parsedUrl.password) {
+      throw new Error('feed URL must not contain credentials');
+    }
+    if (await isPrivateHost(parsedUrl.hostname)) {
+      throw new Error('feed URL host is not allowed (private / loopback / link-local)');
+    }
+
     const response = await axios.get(feedUrl, {
       timeout: FEED_FETCH_TIMEOUT_MS,
       maxContentLength: FEED_MAX_BYTES,
+      maxBodyLength: FEED_MAX_BYTES,
       // Many servers return the feed body differently if axios sends
       // `Accept: application/json,*/*` (the default). Restrict to feed-ish
       // content types and identify ourselves so the request is debuggable.
@@ -46,8 +129,30 @@ export class RssAtomFeedClient {
       },
       // Treat non-2xx as errors (axios default), but propagate the message
       // so the caller can surface it in the JSON error response.
-      responseType: 'text'
+      responseType: 'text',
+      // Re-validate every redirect target so an open redirect on a public
+      // host can't bounce us to internal infrastructure.
+      maxRedirects: 5,
+      beforeRedirect: async (opts) => {
+        const next = new URL(opts.href ?? `${opts.protocol}//${opts.hostname}${opts.path}`);
+        if (next.username || next.password) {
+          throw new Error('redirect target must not contain credentials');
+        }
+        if (await isPrivateHost(next.hostname)) {
+          throw new Error('redirect target host is not allowed');
+        }
+      }
     });
+
+    // Pre-flight reject DOCTYPE / ENTITY declarations to prevent
+    // billion-laughs and external-entity expansion before xml2js sees them.
+    // We only inspect the head of the body since these declarations must
+    // appear in the prolog.
+    const head = String(response.data).slice(0, 4096);
+    if (/<!DOCTYPE|<!ENTITY/i.test(head)) {
+      throw new Error('feed contains DOCTYPE/ENTITY declarations (rejected for safety)');
+    }
+
     const parsed = await parseStringPromise(response.data, {
       explicitArray: false,
       ignoreAttrs: false
@@ -68,38 +173,59 @@ export class RssAtomFeedClient {
 
   normalizeAtom(feed) {
     const entries = this.toArray(feed.entry);
-    return entries
-      .map((entry) => ({
-        type: 'article',
-        date: this.pickDate(entry.published, entry.updated),
-        title: this.text(entry.title) || 'No title',
-        url: this.atomLink(entry.link) || ''
-      }))
-      .filter((e) => e.date);
+    let dropped = 0;
+    const events = entries
+      .map((entry) => {
+        const date = this.pickDate(entry.published, entry.updated);
+        if (!date) { dropped++; return null; }
+        return {
+          type: 'article',
+          date,
+          title: this.text(entry.title) || 'No title',
+          url: this.atomLink(entry.link) || ''
+        };
+      })
+      .filter(Boolean);
+    if (dropped > 0) console.warn(`atom feed: dropped ${dropped} entries with no parseable date`);
+    return events;
   }
 
   normalizeRss20(channel) {
     const items = this.toArray(channel.item);
-    return items
-      .map((item) => ({
-        type: 'article',
-        date: this.pickDate(item.pubDate, item['dc:date']),
-        title: this.text(item.title) || 'No title',
-        url: this.text(item.link) || ''
-      }))
-      .filter((e) => e.date);
+    let dropped = 0;
+    const events = items
+      .map((item) => {
+        const date = this.pickDate(item.pubDate, item['dc:date']);
+        if (!date) { dropped++; return null; }
+        return {
+          type: 'article',
+          date,
+          title: this.text(item.title) || 'No title',
+          url: this.text(item.link) || ''
+        };
+      })
+      .filter(Boolean);
+    if (dropped > 0) console.warn(`rss feed: dropped ${dropped} items with no parseable date`);
+    return events;
   }
 
   normalizeRdf(rdf) {
     const items = this.toArray(rdf.item);
-    return items
-      .map((item) => ({
-        type: 'article',
-        date: this.pickDate(item['dc:date'], item.pubDate),
-        title: this.text(item.title) || 'No title',
-        url: this.text(item.link) || ''
-      }))
-      .filter((e) => e.date);
+    let dropped = 0;
+    const events = items
+      .map((item) => {
+        const date = this.pickDate(item['dc:date'], item.pubDate);
+        if (!date) { dropped++; return null; }
+        return {
+          type: 'article',
+          date,
+          title: this.text(item.title) || 'No title',
+          url: this.text(item.link) || ''
+        };
+      })
+      .filter(Boolean);
+    if (dropped > 0) console.warn(`rdf feed: dropped ${dropped} items with no parseable date`);
+    return events;
   }
 
   /** Coerce xml2js single-or-many output into an array (empty for null/undefined). */
@@ -112,12 +238,16 @@ export class RssAtomFeedClient {
    * Extract text content from an xml2js node.
    * xml2js with `ignoreAttrs: false` collapses simple text into a string,
    * but a node with attributes becomes `{ _: 'text', $: { ... } }`.
+   * For unknown structures (e.g. Atom `type='xhtml'` which embeds a `<div>`)
+   * we return '' rather than `String({...})` which would leak `[object Object]`.
    */
   text(v) {
     if (v == null) return '';
     if (typeof v === 'string') return v;
-    if (typeof v === 'object' && '_' in v) return v._;
-    return String(v);
+    if (typeof v === 'object' && Object.prototype.hasOwnProperty.call(v, '_')) {
+      return typeof v._ === 'string' ? v._ : '';
+    }
+    return '';
   }
 
   /**
@@ -137,15 +267,18 @@ export class RssAtomFeedClient {
 
   /**
    * Atom <link> can be a single object, an array, or a plain string.
-   * Prefer rel="alternate" (canonical entry URL); fall back to the first
-   * link with no rel; then any href; then the bare string form.
+   * Prefer rel="alternate" (canonical entry URL) or no-rel; reject other
+   * rels (self / enclosure / via / hub / related etc.) so we don't accidentally
+   * surface non-article links as the entry URL.
    */
   atomLink(linkField) {
     if (!linkField) return '';
     const links = this.toArray(linkField);
-    const preferred = links.find((l) => l?.$ && (l.$.rel === 'alternate' || !l.$.rel));
+    const preferred = links.find((l) => {
+      const rel = l?.$?.rel;
+      return ALLOWED_LINK_RELS.has(rel);
+    });
     if (preferred?.$?.href) return preferred.$.href;
-    if (links[0]?.$?.href) return links[0].$.href;
     if (typeof links[0] === 'string') return links[0];
     return '';
   }
@@ -160,6 +293,9 @@ export class RssAtomFeedClient {
    */
   async getComprehensiveActivity(feedUrl, username) {
     const events = await this.fetchEvents(feedUrl);
+    if (events.length === 0) {
+      throw new Error('feed contained no dated entries');
+    }
     events.sort((a, b) => new Date(b.date) - new Date(a.date));
     return {
       username: username || feedUrl,


### PR DESCRIPTION
## 関連 Issue
closes #7

## 変更内容

### `src/services/rss.js` (新規)
- `RssAtomFeedClient` クラスを追加
- Atom 1.0 / RSS 2.0 / RSS 1.0 (RDF) の 3 形式に対応
- 日付抽出は複数フィールドにフォールバック:
  - Atom: `published` → `updated`
  - RSS 2.0: `pubDate` → `dc:date`
  - RDF: `dc:date` → `pubDate`
- 出力形式は GitHub/Hatena クライアントと共通の `{ username, events, totalActivity, fetchedAt }`
- 各イベント: `{ type: 'article', date, title, url }`
- タイムアウト 15s、最大ペイロード 5MB

### `src/server.js`
- `VALID_SOURCES` に `rss` 追加
- 新 `feed` クエリパラメータ（http/https URL、~2KB 上限）
- `source=rss` のとき `feed` 必須、それ以外では破棄
- キャッシュキーに feed URL の base64url ハッシュ（16 文字切り出し）を追加して衝突回避
- `renderEmbed` に `__FEED__` placeholder 追加

### `src/renderer/embed.html`
- `PARAMS.feed` を保持し、`graphUrl()` で `&feed=` を URLSearchParams に追加

### `src/renderer/webp-generator.js`
- `RssAtomFeedClient` を import
- `fetchActivityData(username, source, feed)` で source=rss 経路を追加
- `generateAnimatedWebP` / `generateView` のシグネチャに `feed` 追加

## Acceptance criteria

- [x] フィード URL を ingest して normalized events に変換
- [x] 視覚化レイヤー（graph.html / data-processor.js）に source 固有ロジックなし
- [x] Atom / RSS 2.0 / RDF の date extraction を頑健に処理
- [x] Documentation で「フィードは直近 N 件のみのため posting-time bias の傾向把握用」と limitation 明記

## 動作確認

```
source=rss without feed:        400
source=rss with bad feed:       400
source=rss with valid feed:     200
source=github (regression):     200
feed injection in PARAMS:       feed: "https://example.com/rss"
```

RssAtomFeedClient の単体検証（スタブ XML 投入）:
- Atom: `published` 優先、`alternate` link 採用
- RSS 2.0: `pubDate` を ISO に正規化
- RDF: `dc:date`（タイムゾーン付き）を UTC に正規化

## 触らないもの
- `graph.html` / `palette.js` / `data-processor.js`（視覚化レイヤーは source 非依存）
- 既存 GitHub / Hatena クライアント