### PR TITLE
Phase 7: refactor input sources into a unified provider/adapter architecture (#8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ kira-activity/
 ├── src/
 │   ├── server.js                 # Hono サーバー（エントリーポイント）
 │   ├── services/
+│   │   ├── registry.js           # provider registry + 共通 fetchActivity dispatcher
 │   │   ├── github.js             # GitHub API クライアント
 │   │   ├── hatena.js             # はてなブックマーク API
 │   │   ├── rss.js                # 汎用 RSS/Atom/RDF フィードクライアント
@@ -48,6 +49,69 @@ kira-activity/
 ├── package.json
 └── .env.example
 ```
+
+## Provider アーキテクチャ
+
+データソース層は `src/services/registry.js` の **provider registry** に集約されている。
+ルーティング層・レンダリング層からはソース固有の分岐が完全に消えており、新しいデータ
+ソースを追加するには registry に 1 エントリ足すだけで済む。
+
+```
+server.js ──> services/registry.js ──┬── github (GitHubClient adapter)
+   │              │                  ├── hatena (HatenaBookmarkClient adapter)
+   │              │                  └── rss    (RssAtomFeedClient adapter)
+   │              │
+   │              └── fetchActivity(source, { user, feed }) — 共通契約
+   ▼
+webp-generator.js / data-processor.js
+   ↑
+   └── ソース固有の if/else は持たない（normalized activity だけを消費）
+```
+
+### Provider contract
+
+```js
+{
+  source: 'github',
+  fetchActivity: async ({ user, feed }) => NormalizedActivity
+}
+```
+
+`NormalizedActivity` の target shape:
+
+```js
+{
+  username,
+  totalActivity,
+  events: [
+    { date, type, title?, url?, repo?, meta? }
+  ],
+  fetchedAt
+}
+```
+
+現状の各 client（`GitHubClient` / `HatenaBookmarkClient` / `RssAtomFeedClient`）の
+`getComprehensiveActivity` 戻り値はこの shape にすでに十分互換で、`events[]` 内の
+個別エントリは `event.message || event.title || event.comment || 'Activity'` のような
+data-processor 側のフォールバックを通って消費される。target shape は forward-looking な
+ガイドラインで、後方互換のために既存の event 形を強制変換はしない。
+
+### `VALID_SOURCES` の真の source-of-truth
+
+`server.js` の `VALID_SOURCES` は `registry.js` の `SUPPORTED_SOURCES` から導出して
+いる。新しい source を増やすときは:
+
+1. `services/registry.js` の `PROVIDERS` に 1 エントリを追加（必要なら新しい client を import）
+2. それだけ。route / webp-generator / palette は触らない
+
+### in-flight dedup
+
+`/embed` は kira / month / week の 3 ビュー WebP を並列に pre-warm するため、同じ
+`(source, user, feed)` に対して 3 連射の fetch が走る可能性がある。registry の
+`fetchActivity` は `inFlight: Map<key, Promise>` で in-flight な Promise を共有し、
+upstream fetch を 1 回に集約する。`finally` で entry を消すので、エラーが永続キャッシュ
+に化けることはない。以前 webp-generator にあった `inFlightFeeds`（rss 専用）は
+registry に統合済み — 全 source に対して同じ dedup ロジックが効く。
 
 ## エンドポイント
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,13 @@ data-processor 側のフォールバックを通って消費される。target s
 いる。新しい source を増やすときは:
 
 1. `services/registry.js` の `PROVIDERS` に 1 エントリを追加（必要なら新しい client を import）
-2. それだけ。route / webp-generator / palette は触らない
+2. data fetch contract はそれで完結。route / webp-generator / palette は触らない
+
+ただし route policy（user の文字種、必要な追加クエリ、エラーマスキング等）は source
+固有の判断が残る。新 source が github/hatena 系の ID-style か rss 系の URL-style か
+で決まらない第三カテゴリ（OAuth 認証など）の場合は `server.js` 側のバリデーション・
+キャッシュキーにも分岐が必要。registry は data layer の統一であって、route layer の
+policy は別軸。
 
 ### in-flight dedup
 
@@ -111,7 +117,9 @@ data-processor 側のフォールバックを通って消費される。target s
 `fetchActivity` は `inFlight: Map<key, Promise>` で in-flight な Promise を共有し、
 upstream fetch を 1 回に集約する。`finally` で entry を消すので、エラーが永続キャッシュ
 に化けることはない。以前 webp-generator にあった `inFlightFeeds`（rss 専用）は
-registry に統合済み — 全 source に対して同じ dedup ロジックが効く。
+registry に統合済み — 全 source に対して同じ dedup ロジックが効く。dedup の identity
+は provider が `inflightIdentity()` で上書きできる: rss は user がラベル扱いなので
+feed のみで keying し、同じ feed を別ラベルで叩く並列リクエストも 1 fetch に集約する。
 
 ## エンドポイント
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Death Note L 風のアクティビティ可視化ウィジェット。GitHub や
    └─ /api/graph ──── /embed?view=auto を WebP として書き出すエクスポート層
 ```
 
+データソース（`github` / `hatena` / `rss`）は `src/services/registry.js` の
+**provider registry** に共通契約 `fetchActivity({ user, feed })` で登録されており、
+ルート層・レンダラ層からはソース固有の分岐が消えている。新しいデータソースを足したい
+ときは registry に 1 エントリを追加するだけ（詳細は `CLAUDE.md` の
+「Provider アーキテクチャ」を参照）。
+
 ## 使い方
 
 ```bash

--- a/docs/visual-direction.md
+++ b/docs/visual-direction.md
@@ -254,6 +254,10 @@ WebAssembly 実装でネイティブビルド依存はないが、ライセン�
 2. ~~`kira` ビューを Kira Screen として再設計~~（Phase 2 完了: surface + wireframe + peak edge）
 3. ~~`week` ビューを Weekly Overlay 主役の見た目に再設計~~（Phase 3 完了: 7×24 累積オーバーレイ）
 4. ~~`month` ビューを Month View として再定義~~（Phase 3 完了: Sun..Sat カレンダー + per-cell 24h strip）
+5. ~~ソース層を provider registry に統合~~（Phase 7 完了: `services/registry.js` に
+   `github` / `hatena` / `rss` を共通 contract で登録。ルート / レンダラから source 別
+   分岐が消え、新 source は registry に 1 エントリで足せる。in-flight dedup も registry
+   に集約され、全 source で `(source, user, feed)` 単位に効く）
 
 ### Cloudflare hosting note
 

--- a/src/renderer/webp-generator.js
+++ b/src/renderer/webp-generator.js
@@ -58,8 +58,8 @@ async function getBrowser() {
  * Generate animated WebP cycling through kira -> month -> week.
  * Used by /api/graph?view=auto (the canonical export of /embed).
  *
- * @param {string} username - Username (GitHub or Hatena)
- * @param {string} source - 'github' or 'hatena'
+ * @param {string} username - User identifier or display label (depends on source)
+ * @param {string} source - SUPPORTED_SOURCES のいずれか ('github' | 'hatena' | 'rss')
  * @param {string} theme - Visualization theme. VALID_THEMES のいずれか
  *   ('film' | 'github' | 'hatena' | 'sepia' | 'mono')。それ以外は film にフォールバック。
  * @param {string} size - 'small' | 'medium' | 'large'
@@ -103,7 +103,7 @@ export async function generateAnimatedWebP(username, source, theme, size, palett
  * Used by /api/graph?view=kira|month|week.
  *
  * @param {string} username
- * @param {string} source - 'github' | 'hatena'
+ * @param {string} source - SUPPORTED_SOURCES のいずれか ('github' | 'hatena' | 'rss')
  * @param {'kira'|'month'|'week'} view
  * @param {string} theme - VALID_THEMES のいずれか
  *   ('film' | 'github' | 'hatena' | 'sepia' | 'mono')。それ以外は film にフォールバック。

--- a/src/renderer/webp-generator.js
+++ b/src/renderer/webp-generator.js
@@ -4,25 +4,12 @@ import webpmux from 'node-webpmux';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
-import { GitHubClient } from '../services/github.js';
-import { HatenaBookmarkClient } from '../services/hatena.js';
-import { RssAtomFeedClient } from '../services/rss.js';
+import { fetchActivity } from '../services/registry.js';
 import { DataProcessor } from '../utils/data-processor.js';
 import { getPalette, sanitizePalette } from './palette.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-
-const githubClient = new GitHubClient();
-const hatenaClient = new HatenaBookmarkClient();
-const rssClient = new RssAtomFeedClient();
-
-// In-flight request deduplication for source=rss. /embed pre-warms three
-// single-view WebPs in parallel, so without dedup we'd fire three identical
-// fetches at the upstream feed within milliseconds. Sharing one Promise
-// keyed by feed URL collapses that to a single fetch; the entry is cleared
-// once the Promise settles so a later cache miss can refetch normally.
-const inFlightFeeds = new Map();
 
 // Singleton browser instance for better performance
 let browserInstance = null;
@@ -149,43 +136,12 @@ export async function generateView(username, source, view, theme, size, palette,
 }
 
 /**
- * Fetch activity data from source.
- * For source='rss', the `feed` URL is required and is used both for the
- * actual fetch and as the implicit identity (the `username` becomes a
- * display label only).
+ * Fetch normalized activity via the provider registry.
+ * Source-specific branches now live in services/registry.js, not here.
  */
 async function fetchActivityData(username, source, feed) {
   console.log(`Fetching ${source} data for ${username}...`);
-
-  if (source === 'github') {
-    return await githubClient.getComprehensiveActivity(username);
-  }
-  if (source === 'hatena') {
-    return await hatenaClient.getComprehensiveActivity(username);
-  }
-  if (source === 'rss') {
-    if (!feed) {
-      throw new Error('feed URL required for source=rss');
-    }
-    // Dedupe concurrent fetches against the same feed URL. The first caller
-    // installs a Promise; subsequent callers (e.g. parallel pre-warm of
-    // kira / month / week) await the same Promise. The finally clears the
-    // entry so cache misses after this batch can fetch fresh.
-    const existing = inFlightFeeds.get(feed);
-    if (existing) {
-      return await existing;
-    }
-    const promise = (async () => {
-      try {
-        return await rssClient.getComprehensiveActivity(feed, username);
-      } finally {
-        inFlightFeeds.delete(feed);
-      }
-    })();
-    inFlightFeeds.set(feed, promise);
-    return await promise;
-  }
-  throw new Error(`Unknown source: ${source}`);
+  return await fetchActivity(source, { user: username, feed });
 }
 
 /**

--- a/src/server.js
+++ b/src/server.js
@@ -8,6 +8,7 @@ import { createHash } from 'crypto';
 import { generateAnimatedWebP, generateView, shutdown as shutdownRenderer } from './renderer/webp-generator.js';
 import { getPalette, sanitizePalette, VALID_THEMES as PALETTE_THEMES } from './renderer/palette.js';
 import { CacheManager } from './services/cache.js';
+import { SUPPORTED_SOURCES } from './services/registry.js';
 
 dotenv.config();
 
@@ -17,8 +18,11 @@ const __dirname = dirname(__filename);
 const PORT = Number(process.env.PORT) || 3000;
 const cache = new CacheManager();
 
-// Shared query param contract
-const VALID_SOURCES = new Set(['github', 'hatena', 'rss']);
+// Shared query param contract.
+// VALID_SOURCES is derived from the provider registry — adding a new source
+// is a single edit to services/registry.js and the route layer picks it up
+// automatically.
+const VALID_SOURCES = new Set(SUPPORTED_SOURCES);
 const VALID_THEMES = new Set(PALETTE_THEMES);
 const VALID_SIZES = new Set(['small', 'medium', 'large']);
 const VALID_VIEWS = new Set(['kira', 'month', 'week', 'auto']);

--- a/src/services/registry.js
+++ b/src/services/registry.js
@@ -24,6 +24,10 @@ import { RssAtomFeedClient } from './rss.js';
  * @typedef {Object} ActivityProvider
  * @property {string} source - Source identifier matching VALID_SOURCES
  * @property {(params: { user: string, feed?: string }) => Promise<NormalizedActivity>} fetchActivity
+ * @property {(params: { user: string, feed?: string }) => string} [inflightIdentity]
+ *   Optional. Returns the value used to dedupe in-flight requests. Defaults to
+ *   `${user}\0${feed}`. Override when, for example, two requests should share
+ *   an upstream fetch even if their `user` labels differ (rss).
  */
 
 const githubClient = new GitHubClient();
@@ -63,7 +67,11 @@ const PROVIDERS = {
     fetchActivity: async ({ user, feed }) => {
       if (!feed) throw new Error('feed URL required for source=rss');
       return await rssClient.getComprehensiveActivity(feed, user);
-    }
+    },
+    // For rss, `user` is a display label only (it is not part of the cache
+    // key in server.js either), so two parallel requests for the same feed
+    // with different labels should share one upstream fetch.
+    inflightIdentity: ({ feed }) => `feed:${feed ?? ''}`
   }
 };
 
@@ -83,8 +91,8 @@ export function getProvider(source) {
  */
 const inFlight = new Map();
 
-function inflightKey(source, user, feed) {
-  return `${source}\0${user}\0${feed ?? ''}`;
+function defaultInflightIdentity({ user, feed }) {
+  return `${user}\0${feed ?? ''}`;
 }
 
 /**
@@ -95,11 +103,13 @@ function inflightKey(source, user, feed) {
  * @param {{ user: string, feed?: string }} params
  * @returns {Promise<NormalizedActivity>}
  */
-export async function fetchActivity(source, params) {
+export async function fetchActivity(source, params = {}) {
   const provider = getProvider(source);
   if (!provider) throw new Error(`Unknown source: ${source}`);
+  if (!params.user) throw new Error(`user required for source=${source}`);
 
-  const key = inflightKey(source, params.user, params.feed);
+  const identity = (provider.inflightIdentity ?? defaultInflightIdentity)(params);
+  const key = `${source}\0${identity}`;
   const existing = inFlight.get(key);
   if (existing) return existing;
 

--- a/src/services/registry.js
+++ b/src/services/registry.js
@@ -1,0 +1,117 @@
+import { GitHubClient } from './github.js';
+import { HatenaBookmarkClient } from './hatena.js';
+import { RssAtomFeedClient } from './rss.js';
+
+/**
+ * @typedef {Object} ActivityEvent
+ * @property {string} date - ISO 8601 timestamp
+ * @property {string} type - Event type label (e.g., 'commit', 'bookmark', 'article')
+ * @property {string} [title]
+ * @property {string} [url]
+ * @property {string} [repo]
+ * @property {object} [meta]
+ */
+
+/**
+ * @typedef {Object} NormalizedActivity
+ * @property {string} username
+ * @property {number} totalActivity
+ * @property {ActivityEvent[]} events
+ * @property {string} fetchedAt
+ */
+
+/**
+ * @typedef {Object} ActivityProvider
+ * @property {string} source - Source identifier matching VALID_SOURCES
+ * @property {(params: { user: string, feed?: string }) => Promise<NormalizedActivity>} fetchActivity
+ */
+
+const githubClient = new GitHubClient();
+const hatenaClient = new HatenaBookmarkClient();
+const rssClient = new RssAtomFeedClient();
+
+/**
+ * Provider implementations.
+ *
+ * Each adapter wraps the underlying service client (which still has its own
+ * domain-specific shape) into the common `fetchActivity({ user, feed })`
+ * contract that returns NormalizedActivity. Adding a new source = adding one
+ * entry here, not touching the renderer/route layer.
+ *
+ * Note: the per-client `events[]` shapes are already compatible enough with
+ * the documented target shape ({ date, type, title?, url?, repo?, meta? })
+ * that the renderer / data-processor consume them via the existing
+ * `event.message || event.title || event.comment || 'Activity'` fallback.
+ * The target shape is the forward-looking guideline; we do not rewrite
+ * existing client output here to preserve backward compatibility.
+ */
+const PROVIDERS = {
+  github: {
+    source: 'github',
+    fetchActivity: async ({ user }) => {
+      return await githubClient.getComprehensiveActivity(user);
+    }
+  },
+  hatena: {
+    source: 'hatena',
+    fetchActivity: async ({ user }) => {
+      return await hatenaClient.getComprehensiveActivity(user);
+    }
+  },
+  rss: {
+    source: 'rss',
+    fetchActivity: async ({ user, feed }) => {
+      if (!feed) throw new Error('feed URL required for source=rss');
+      return await rssClient.getComprehensiveActivity(feed, user);
+    }
+  }
+};
+
+/**
+ * Lookup a provider by its source key. Returns null when unknown so callers
+ * can produce clean 4xx-style errors.
+ */
+export function getProvider(source) {
+  return PROVIDERS[source] ?? null;
+}
+
+/**
+ * In-flight deduplication: when multiple concurrent requests target the same
+ * (source, user, feed) tuple — typically the embed pre-warming kira/month/week
+ * in parallel — we collapse them onto a single upstream fetch. Each entry is
+ * removed in `finally` so that errors do not poison the cache.
+ */
+const inFlight = new Map();
+
+function inflightKey(source, user, feed) {
+  return `${source}\0${user}\0${feed ?? ''}`;
+}
+
+/**
+ * Fetch normalized activity. Dispatch + dedup live here so the renderer never
+ * sees source-specific branches.
+ *
+ * @param {string} source
+ * @param {{ user: string, feed?: string }} params
+ * @returns {Promise<NormalizedActivity>}
+ */
+export async function fetchActivity(source, params) {
+  const provider = getProvider(source);
+  if (!provider) throw new Error(`Unknown source: ${source}`);
+
+  const key = inflightKey(source, params.user, params.feed);
+  const existing = inFlight.get(key);
+  if (existing) return existing;
+
+  const promise = (async () => {
+    try {
+      return await provider.fetchActivity(params);
+    } finally {
+      inFlight.delete(key);
+    }
+  })();
+  inFlight.set(key, promise);
+  return promise;
+}
+
+export const SUPPORTED_SOURCES = Object.freeze(Object.keys(PROVIDERS));


### PR DESCRIPTION
## 関連 Issue
closes #8

## 変更内容

### 新規 `src/services/registry.js`
- Provider contract (JSDoc) を定義: `{ source, fetchActivity({ user, feed }) -> NormalizedActivity }`
- 既存 `GitHubClient` / `HatenaBookmarkClient` / `RssAtomFeedClient` を adapter で薄くラップ
- `getProvider(source)` lookup
- `fetchActivity(source, params)` dispatcher
- in-flight dedup を全 source 対応に統一（旧 webp-generator にあった rss 専用 Map から昇格）
- `SUPPORTED_SOURCES` を export

### `src/renderer/webp-generator.js`
- source 別 if/else 分岐を撤去
- module-level `inFlightFeeds` Map を削除（registry に移動）
- `fetchActivityData` は `fetchActivity(source, { user, feed })` を呼ぶだけに

### `src/server.js`
- `VALID_SOURCES` を `SUPPORTED_SOURCES` から派生（DRY、registry を真の source-of-truth に）

### 既存 client は触らない
- `github.js` / `hatena.js` / `rss.js` の class シグネチャは維持
- 戻り値はすでに target normalized shape (`{ username, totalActivity, events, fetchedAt }`) と互換

## Acceptance criteria

- [x] `github` / `hatena` / `rss` すべて同じ provider contract で動作
- [x] route/controller layer から source 別 fetch 分岐を排除
- [x] rendering / aggregation layer は normalized activity のみ消費（変更なし）
- [x] 新 source は registry の 1 エントリ追加だけで導入可能
- [x] Phase 6 RSS は registry 経由で自然に統合

## 動作確認

```
SUPPORTED_SOURCES: ['github', 'hatena', 'rss']
getProvider('mastodon'): null
in-flight dedup: 並列 3 リクエストで underlying fetch は 1 回のみ

/embed?user=foo                                   → 200
/embed?user=foo&source=hatena                     → 200
/embed?user=foo&source=rss&feed=...               → 200
/embed?user=foo&source=mastodon                   → 400
```