### PR TITLE
Phase 8: rename public endpoints to common, user-facing names (#9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,16 +14,16 @@ L がキラの活動パターンを段階的に分析していくシーンを再
 
 ## アーキテクチャ
 
-`/embed` を**正本のレンダラー**とし、`/api/graph` はその上に乗る WebP エクスポート層。
+`/viewer` を**正本のレンダラー**とし、`/image` はその上に乗る WebP エクスポート層。
 
 ```
-Client ──> Hono Server ──┬── /embed       (HTML, iframe 用)
+Client ──> Hono Server ──┬── /viewer      (HTML, iframe 用)
                          │       │
                          │       └── 同じクエリ仕様
                          │              │
-                         └── /api/graph (Puppeteer + Sharp で /embed?view=auto を WebP 化)
+                         └── /image     (Puppeteer + Sharp で /viewer?view=auto を WebP 化)
                                 ↑
-                                └── /embed?view=kira|month|week なら単一ビュー WebP
+                                └── /viewer?view=kira|month|week なら単一ビュー WebP
 ```
 
 データ取得層は `services/github.js` / `services/hatena.js`、変換は `utils/data-processor.js`、描画は `renderer/graph.html`。
@@ -41,7 +41,7 @@ kira-activity/
 │   │   ├── rss.js                # 汎用 RSS/Atom/RDF フィードクライアント
 │   │   └── cache.js              # キャッシュ管理
 │   ├── renderer/
-│   │   ├── embed.html            # /embed の HTML テンプレート（Phase 0 placeholder）
+│   │   ├── embed.html            # /viewer の HTML テンプレート（ファイル名は git history 都合で温存）
 │   │   ├── graph.html            # Three.js 可視化テンプレート（Puppeteer 用）
 │   │   └── webp-generator.js     # Puppeteer + WebP 生成
 │   └── utils/
@@ -112,7 +112,7 @@ policy は別軸。
 
 ### in-flight dedup
 
-`/embed` は kira / month / week の 3 ビュー WebP を並列に pre-warm するため、同じ
+`/viewer` は kira / month / week の 3 ビュー WebP を並列に pre-warm するため、同じ
 `(source, user, feed)` に対して 3 連射の fetch が走る可能性がある。registry の
 `fetchActivity` は `inFlight: Map<key, Promise>` で in-flight な Promise を共有し、
 upstream fetch を 1 回に集約する。`finally` で entry を消すので、エラーが永続キャッシュ
@@ -127,14 +127,15 @@ feed のみで keying し、同じ feed を別ラベルで叩く並列リクエ�
 |---|---|
 | `GET /` | デモページ（HTML） |
 | `GET /health` | ヘルスチェック |
-| `GET /embed` | 正本レンダラー（HTML） |
-| `GET /api/graph` | `/embed` の WebP エクスポート |
+| `GET /viewer` | 正本レンダラー（HTML） |
+| `GET /image` | `/viewer` の WebP エクスポート |
 
-旧 `/api/frame` は廃止。単一ビュー出力は `/api/graph?view=kira|month|week` を使う。
+旧 `/api/frame` は廃止。単一ビュー出力は `/image?view=kira|month|week` を使う。
+旧 `/embed` / `/api/graph` も Phase 8 で `/viewer` / `/image` に改名済み（後方互換なし）。
 
 ## 共有クエリパラメータ
 
-`/embed` と `/api/graph` で同じ仕様。
+`/viewer` と `/image` で同じ仕様。
 
 - `user` (必須。`source=rss` のときは表示用ラベル)
 - `source` (`github` | `hatena` | `rss`、default `github`)
@@ -176,7 +177,7 @@ XSS は既存の `JSON.stringify(...).replace(/</g, '\\u003c')` 注入パター�
 - **XXE 対策**: 取得した body の先頭 4 KB に `<!DOCTYPE` / `<!ENTITY` が含まれていたら
   xml2js に渡す前に reject する（billion-laughs / 外部実体展開対策）
 - **URL 長制限**: `feed` は 1024 文字以内（Cloudflare 等の CDN 長さ制限を考慮）
-- **in-flight dedup**: `/embed` の 3 ビュー pre-warm が同じ feed に対して 3 連射しても、
+- **in-flight dedup**: `/viewer` の 3 ビュー pre-warm が同じ feed に対して 3 連射しても、
   webp-generator の module-level `inFlightFeeds: Map<feedUrl, Promise>` が単一の
   Promise を共有するので fetch は 1 回に集約される
 - **エラー応答**: `source=rss` 経路の 500 は `details: 'feed fetch failed'` の
@@ -206,8 +207,8 @@ accent / highlight）× 5 テーマで定義する。
   `hatena`→くすんだ青）。background / ink / grid / highlight はフィルム配色のまま。
 - 他のテーマ（`github` / `hatena` / `sepia` / `mono`）はテーマ自身の配色を優先し、
   source による accent 切り替えは行わない。
-- パレットはサーバ側で 1 回だけ resolve し、`/embed` には CSS 変数（`--kira-bg` ほか）
-  として、`/api/graph` には `window.RENDER_PALETTE` として注入される。
+- パレットはサーバ側で 1 回だけ resolve し、`/viewer` には CSS 変数（`--kira-bg` ほか）
+  として、`/image` には `window.RENDER_PALETTE` として注入される。
 - CSS 注入の安全性は `sanitizePalette()` が `^#[0-9a-fA-F]{6}$` を保証することで担保。
   JS 注入は既存の `JSON.stringify(...).replace(/</g, '\\u003c')` パターン。
 
@@ -311,13 +312,13 @@ Node.js より 2–3 倍高速（`bun src/server.js`）。
 
 ### src/renderer/embed.html
 
-- `/embed` が返す HTML
-- `<img id="kira-image">` に `/api/graph` を読み込ませて表示する。Three.js は
+- `/viewer` が返す HTML（ファイル名 `embed.html` は git history 都合で温存）
+- `<img id="kira-image">` に `/image` を読み込ませて表示する。Three.js は
   サーバ側 Puppeteer がすでに WebP 化しているので、iframe では再実行しない
 - `view=auto`: クライアント側で単一ビュー WebP（kira / month / week）をサイクル
   時間ごとに `<img>.src` swap し、ドットと画像を完全同期させる。`performance.now()`
   起点の RAF ループ。サイクル長は kira 4s + month 2.5s + week 5s = 11.5s で
-  `webp-generator.js` の dwell time と一致させる。Phase 5 で `/api/graph` が真の
+  `webp-generator.js` の dwell time と一致させる。Phase 5 で `/image` が真の
   animated WebP を返すようになったが、embed.html 側の単一ビュー swap 同期ロジック
   はそのまま維持している（巨大 animated WebP のロード待ちが iframe で目立ちやすく、
   単一ビュー pre-warm + クライアント同期の方が体感品質が高いため）

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -138,7 +138,7 @@ bun run bun     # ~50ms startup (4x faster)
 - RAM: 16GB
 - OS: Ubuntu 22.04
 
-### Test Case: Generate kira/month/week frames for GitHub user "torvalds" via /api/graph?view=auto
+### Test Case: Generate kira/month/week frames for GitHub user "torvalds" via /image?view=auto
 
 | Scenario | Node.js | Bun | Speedup |
 |----------|---------|-----|---------|
@@ -214,7 +214,7 @@ For **high traffic** (> 100 req/min):
 - JS + WebAssembly の muxer 段で +50〜200ms 程度（3 フレームを mux するだけ、
   ネイティブビルド依存なし。node-webpmux のライセンスは LGPL-3.0-or-later）。
   上の Bun ベンチマーク数値（4.1s / 5.9s）はおおむね維持されるが、
-  `/api/graph?view=auto` のみ若干上振れする点に注意
+  `/image?view=auto` のみ若干上振れする点に注意
 
 ### 4. **GPU Acceleration**
 - Use `--enable-gpu` for Three.js rendering

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Death Note L 風のアクティビティ可視化ウィジェット。GitHub や
 
 ## アーキテクチャ
 
-`/embed` を**正本のレンダラー**とし、`/api/graph` はその上に乗る WebP エクスポート層。同じクエリ仕様を両方で共有する。
+`/viewer` を**正本のレンダラー**とし、`/image` はその上に乗る WebP エクスポート層。同じクエリ仕様を両方で共有する。
 
 ```
-/embed  ──── canonical renderer (HTML, iframe 用)
+/viewer ──── canonical renderer (HTML, iframe 用)
    │
-   └─ /api/graph ──── /embed?view=auto を WebP として書き出すエクスポート層
+   └─ /image ──── /viewer?view=auto を WebP として書き出すエクスポート層
 ```
 
 データソース（`github` / `hatena` / `rss`）は `src/services/registry.js` の
@@ -32,10 +32,10 @@ npm start
 ### iframe で埋め込む
 
 ```html
-<iframe src="https://example.com/embed?user=YOUR_USERNAME"></iframe>
+<iframe src="https://example.com/viewer?user=YOUR_USERNAME"></iframe>
 ```
 
-`/embed` は `/api/graph` を `<img>` として読み込む。`view=auto` のときは embed 側が
+`/viewer` は `/image` を `<img>` として読み込む。`view=auto` のときは viewer 側が
 クライアントサイドで単一ビュー WebP（`kira` / `month` / `week`）をサイクル時間ごとに
 swap し、下部のカルーセルドットと画像を完全同期させる。ドットをクリックすると自動再生を
 停止して該当ビューの単一 WebP に opacity フェードで切り替わる。`view=kira|month|week`
@@ -44,18 +44,18 @@ swap し、下部のカルーセルドットと画像を完全同期させる。
 ### README に画像として貼る
 
 ```markdown
-![Activity](https://example.com/api/graph?user=YOUR_USERNAME)
+![Activity](https://example.com/image?user=YOUR_USERNAME)
 ```
 
 ## エンドポイント
 
-- `GET /embed` — 正本レンダラー（HTML を返す）
-- `GET /api/graph` — `/embed` の WebP エクスポート。`view=auto`（デフォルト）は kira → month → week をループする真の animated WebP、`view=kira|month|week` は単一ビューの静止 WebP
+- `GET /viewer` — 正本レンダラー（HTML を返す）
+- `GET /image` — `/viewer` の WebP エクスポート。`view=auto`（デフォルト）は kira → month → week をループする真の animated WebP、`view=kira|month|week` は単一ビューの静止 WebP
 - `GET /health` — ヘルスチェック
 
 ## 共有クエリパラメータ
 
-`/embed` と `/api/graph` で同じクエリ仕様を使う。
+`/viewer` と `/image` で同じクエリ仕様を使う。
 
 | パラメータ | 値 | デフォルト | 説明 |
 |---|---|---|---|
@@ -101,7 +101,7 @@ swap し、下部のカルーセルドットと画像を完全同期させる。
 - `kira` — 曜日 × 時刻の活動量を 3D サーフェスで俯瞰、ピーク時刻が発光ラインで強調
 - `month` — 直近 ~30 日を Sun..Sat 7 列カレンダーとして配置。日セルの濃度で日量、セル右の 24 本ストリップで時刻帯を表現
 - `week` — 7 × 24 のグリッドに週ごとの活動を半透明レイヤーとして累積。同じ時間帯に活動が重なるほど濃くなり、繰り返し bias が見える
-- `auto` — 上記を順に再生するアニメーション（`/api/graph` のデフォルト挙動）
+- `auto` — 上記を順に再生するアニメーション（`/image` のデフォルト挙動）
 
 ### テーマと source-aware accent
 
@@ -117,13 +117,13 @@ swap し、下部のカルーセルドットと画像を完全同期させる。
 
 ## 使用例
 
-- `/embed?user=torvalds` — auto 再生する iframe
-- `/embed?user=torvalds&view=kira` — kira 固定の iframe
-- `/api/graph?user=torvalds` — auto をアニメ WebP として書き出し
-- `/api/graph?user=torvalds&view=week&theme=film&size=large` — 単一ビューの WebP
-- `/api/graph?user=torvalds&source=github&theme=film` — film 配色 + GitHub 緑のアクセント
-- `/api/graph?user=torvalds&source=hatena&theme=film` — film 配色 + はてな青のアクセント
-- `/api/graph?user=foo&source=rss&feed=https%3A%2F%2Fexample.com%2Fatom` — 任意フィードの記事公開時刻を可視化
+- `/viewer?user=torvalds` — auto 再生する iframe
+- `/viewer?user=torvalds&view=kira` — kira 固定の iframe
+- `/image?user=torvalds` — auto をアニメ WebP として書き出し
+- `/image?user=torvalds&view=week&theme=film&size=large` — 単一ビューの WebP
+- `/image?user=torvalds&source=github&theme=film` — film 配色 + GitHub 緑のアクセント
+- `/image?user=torvalds&source=hatena&theme=film` — film 配色 + はてな青のアクセント
+- `/image?user=foo&source=rss&feed=https%3A%2F%2Fexample.com%2Fatom` — 任意フィードの記事公開時刻を可視化
 
 ## 技術スタック
 

--- a/docs/visual-direction.md
+++ b/docs/visual-direction.md
@@ -211,7 +211,7 @@ iframe 用 UI:
 - 手動切り替え
 - モード固定 URL
 
-> Phase 4 で完了。`/embed` が `/image` 駆動の対話的カルーセルとして動く。
+> Phase 4 で完了。`/viewer` が `/image` 駆動の対話的カルーセルとして動く。
 
 ### Phase 3
 
@@ -237,7 +237,7 @@ iframe 用 UI:
 > metadata IP に解決されるホストへの接続を拒否（SSRF 対策）し、リダイレクト先も
 > 再検証する。`<!DOCTYPE>` / `<!ENTITY>` を含む body は xml2js に渡す前に reject
 > する（XXE / billion-laughs 対策）。URL 長は 1024 文字、フェッチサイズは 5 MB
-> 上限。`/embed` の 3 ビュー pre-warm は in-flight Map で 1 fetch に集約。
+> 上限。`/viewer` の 3 ビュー pre-warm は in-flight Map で 1 fetch に集約。
 
 ## Rendering Notes
 

--- a/docs/visual-direction.md
+++ b/docs/visual-direction.md
@@ -46,9 +46,9 @@ API では色指定を `theme` の単語だけで済ませず、最終的には�
 
 例:
 
-- `/api/graph?user=kako-jun&source=github&theme=film` — film 配色 + GitHub 緑のアクセント
-- `/api/graph?user=kako-jun&source=github&theme=github` — GitHub 草配色（accent 固定）
-- `/api/graph?user=kako-jun&source=hatena&theme=film` — film 配色 + はてな青のアクセント
+- `/image?user=kako-jun&source=github&theme=film` — film 配色 + GitHub 緑のアクセント
+- `/image?user=kako-jun&source=github&theme=github` — GitHub 草配色（accent 固定）
+- `/image?user=kako-jun&source=hatena&theme=film` — film 配色 + はてな青のアクセント
 
 ## Core Modes
 
@@ -118,7 +118,7 @@ Three.js のままでもよいが、動きの考え方は p5 的な「美しい�
 
 GitHub のプロフィール右上や README に貼る主戦場。
 
-- Endpoint: `/api/graph`
+- Endpoint: `/image`
 - Return: `image/webp`
 - 中身は animated WebP
 - UI は含まない
@@ -140,9 +140,9 @@ GitHub のプロフィール右上や README に貼る主戦場。
 
 ### B. Single-view export
 
-`/api/frame` は廃止。単一ビューが必要な場合は `/api/graph` に `view` を渡す。
+`/api/frame` は廃止。単一ビューが必要な場合は `/image` に `view` を渡す。
 
-- Endpoint: `/api/graph?view=kira|month|week`
+- Endpoint: `/image?view=kira|month|week`
 - Return: `image/webp`
 - 単一状態を返す
 
@@ -155,7 +155,7 @@ GitHub のプロフィール右上や README に貼る主戦場。
 
 対話的埋め込み。
 
-- Endpoint 例: `/embed?user=...`
+- Endpoint 例: `/viewer?user=...`
 - 自動再生あり
 - 下部にカルーセルの丸を表示
 - 自動遷移も手動選択も可能
@@ -174,15 +174,15 @@ iframe 用 UI:
 - Next.js は採用しない
 
 > **Phase 4 status:** 実装済み。`embed.html` は `<img id="kira-image">` に
-> `/api/graph` を読み込ませる。`view=auto` のときは embed 側がクライアントサイドで
+> `/image` を読み込ませる。`view=auto` のときは viewer 側がクライアントサイドで
 > 単一ビュー WebP（kira / month / week）をサイクル時間ごとに `<img>.src` ごと swap し、
 > ドットと画像を完全同期させる（`performance.now()` 起点 RAF ループ + fade swap）。
 > `view=kira|month|week` のときは単一ビュー WebP を表示し、該当ドットだけ active になる。
 > ドットクリックは auto 同期を停止し、CSS opacity フェード（400ms ease-in-out）で
 > 単一ビュー WebP に切り替わる。読み込み待ちを隠すため、3 つの単一ビュー（kira +
-> month + week）を初期 load 時に並列 pre-warm する（`auto` は embed 側で使わないので除外）。
+> month + week）を初期 load 時に並列 pre-warm する（`auto` は viewer 側で使わないので除外）。
 
-> **Phase 5 status:** 実装済み。`/api/graph?view=auto` は sharp で
+> **Phase 5 status:** 実装済み。`/image?view=auto` は sharp で
 > kira / month / week の 3 フレームをそれぞれ静止 WebP に encode したあと、
 > `node-webpmux` で VP8X + ANIM + ANMF×3 の真の animated WebP コンテナに
 > muxing する。sharp 単体では静止フレーム配列から animated WebP を生成
@@ -199,7 +199,7 @@ iframe 用 UI:
 
 最初に出すべきもの:
 
-- `/api/graph` が **本当に animated WebP を返す**
+- `/image` が **本当に animated WebP を返す**
 - ループは `3D -> month -> week`
 - `theme=film` が完成している
 - `source=github|hatena` でアクセント色が変わる
@@ -211,7 +211,7 @@ iframe 用 UI:
 - 手動切り替え
 - モード固定 URL
 
-> Phase 4 で完了。`/embed` が `/api/graph` 駆動の対話的カルーセルとして動く。
+> Phase 4 で完了。`/embed` が `/image` 駆動の対話的カルーセルとして動く。
 
 ### Phase 3
 
@@ -229,7 +229,7 @@ iframe 用 UI:
 > **Limitation:** ほとんどのサービスはフィードに直近 10〜50 件しか含めない。
 > week ビューの累積は当然この範囲に閉じるため、長期の繰り返し bias を読むツール
 > ではなく、**直近の posting-time bias を眺めるツール**として捉えるのが正しい。
-> `feed` の SHA-256 ハッシュ（base64url 先頭 16 文字）を `/api/graph` のキャッシュキー
+> `feed` の SHA-256 ハッシュ（base64url 先頭 16 文字）を `/image` のキャッシュキー
 > に使い、`source=rss` ではキャッシュキーから `user`（表示ラベル）を除外する。
 > カスタム配色 / JSON 入力は Phase 6 のスコープ外。
 >
@@ -241,7 +241,7 @@ iframe 用 UI:
 
 ## Rendering Notes
 
-`/api/graph` は Phase 5 で真の animated WebP に対応済み。`view=auto`（デフォルト）は
+`/image` は Phase 5 で真の animated WebP に対応済み。`view=auto`（デフォルト）は
 sharp で各フレームを静止 WebP に encode したあと、node-webpmux で kira / month / week
 の 3 フレームを 1 枚の animated WebP（VP8X + ANIM + ANMF×3）に muxing して返す。
 per-frame delay は embed の VIEW_DELAYS と揃えている。node-webpmux は JS +

--- a/src/renderer/embed.html
+++ b/src/renderer/embed.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>KIRA Activity - Embed</title>
+  <title>KIRA Activity - Viewer</title>
   <style>
     :root {
       --kira-bg: __PALETTE_BG__;
@@ -118,9 +118,12 @@
 
   <script>
     // Server-injected params (placeholders replaced at request time).
+    // This template (on-disk filename embed.html, kept for git history
+    // continuity) is served at the public route /viewer and pulls images
+    // from /image.
     // `feed` is the absolute URL of an external RSS/Atom/RDF feed. It is a
     // string only when source === 'rss'; for github/hatena the server
-    // injects null so the client never appends it to /api/graph URLs.
+    // injects null so the client never appends it to /image URLs.
     const PARAMS = {
       user: __USER__,
       source: __SOURCE__,
@@ -136,7 +139,7 @@
     // Ordered to match the auto-loop ordering in webp-generator.js.
     const VIEWS = ['kira', 'month', 'week'];
     // Per-view dwell time in ms. Kept in sync with webp-generator.js waitTime
-    // so the iframe carousel and the /api/graph animated WebP play at the
+    // so the iframe carousel and the /image animated WebP play at the
     // same rhythm. kira (3D) sits 4s as the headline; month renders quickly
     // so 2.5s is enough; week needs the full layering animation to read, so
     // 5s.
@@ -144,11 +147,11 @@
     const CYCLE_TOTAL = VIEWS.reduce((s, v) => s + VIEW_DELAYS[v], 0);
 
     /**
-     * Build a /api/graph URL for the current PARAMS, swapping in the requested
+     * Build a /image URL for the current PARAMS, swapping in the requested
      * view. URL-encoding is mandatory because user names can contain `-` etc.,
      * and we want the same query contract as the server-side parser.
      */
-    function graphUrl(view) {
+    function imageUrl(view) {
       const qs = new URLSearchParams({
         user: PARAMS.user,
         source: PARAMS.source,
@@ -159,7 +162,7 @@
       // Carry the feed URL through so single-view swaps and pre-warming
       // hit the same cache entry the server keyed by feed.
       if (PARAMS.feed) qs.set('feed', PARAMS.feed);
-      return '/api/graph?' + qs.toString();
+      return '/image?' + qs.toString();
     }
 
     const img = document.getElementById('kira-image');
@@ -172,10 +175,10 @@
 
     /**
      * Compute which view the auto carousel is currently showing.
-     * In Phase 4 the embed cycles through single-view WebPs client-side
+     * In Phase 4 the viewer cycles through single-view WebPs client-side
      * (kira -> month -> week), swapping the <img src> at each boundary so
      * dots and image stay perfectly in sync. Phase 5 will replace this with
-     * a true animated WebP from /api/graph?view=auto.
+     * a true animated WebP from /image?view=auto.
      *
      * Using `performance.now()` keeps the loop monotonic (not affected by
      * wall-clock changes) and safe inside iframes. The double-modulo guards
@@ -213,7 +216,7 @@
       setActiveDot(VIEWS[0]);
       // Initial paint: skip the fade so the user sees content immediately
       // when the iframe opens. Subsequent transitions go through swapImage().
-      img.src = graphUrl(VIEWS[0]);
+      img.src = imageUrl(VIEWS[0]);
       autoTick();
     }
 
@@ -240,7 +243,7 @@
       // is visible but the user does not stare at a blank panel.
       setTimeout(() => {
         if (mySeq !== swapSeq) return;
-        img.src = graphUrl(view);
+        img.src = imageUrl(view);
       }, 200);
     }
 
@@ -258,14 +261,14 @@
 
     // Pre-warm the cache for the three single-view WebPs so manual switches
     // and auto carousel transitions are responsive. The server caches
-    // /api/graph results for an hour, so these requests are effectively free
+    // /image results for an hour, so these requests are effectively free
     // after the first visitor for a given user. `auto` is intentionally
-    // excluded: the embed never requests it now that the carousel walks the
+    // excluded: the viewer never requests it now that the carousel walks the
     // single-view URLs itself.
     function prewarm() {
       ['kira', 'month', 'week'].forEach((v) => {
         const pre = new Image();
-        pre.src = graphUrl(v);
+        pre.src = imageUrl(v);
       });
     }
 
@@ -275,7 +278,7 @@
     if (PARAMS.view === 'auto') {
       startAutoSync();
     } else {
-      img.src = graphUrl(PARAMS.view);
+      img.src = imageUrl(PARAMS.view);
       setActiveDot(PARAMS.view);
     }
     prewarm();

--- a/src/renderer/webp-generator.js
+++ b/src/renderer/webp-generator.js
@@ -56,7 +56,7 @@ async function getBrowser() {
 
 /**
  * Generate animated WebP cycling through kira -> month -> week.
- * Used by /api/graph?view=auto (the canonical export of /embed).
+ * Used by /image?view=auto (the canonical export of /viewer).
  *
  * @param {string} username - User identifier or display label (depends on source)
  * @param {string} source - SUPPORTED_SOURCES のいずれか ('github' | 'hatena' | 'rss')
@@ -87,7 +87,7 @@ export async function generateAnimatedWebP(username, source, theme, size, palett
   console.log(`Rendered ${frames.length} frames in ${renderTime}ms (parallel)`);
 
   // Per-frame delays in ms, matching ALL_VIEWS order (kira, month, week).
-  // These are the same dwell times used by /embed VIEW_DELAYS and the
+  // These are the same dwell times used by /viewer VIEW_DELAYS and the
   // per-scene waitTime in renderScene(), so the iframe and the export
   // feel identical.
   const FRAME_DELAYS = [4000, 2500, 5000];
@@ -100,7 +100,7 @@ export async function generateAnimatedWebP(username, source, theme, size, palett
 
 /**
  * Generate a single-view WebP export.
- * Used by /api/graph?view=kira|month|week.
+ * Used by /image?view=kira|month|week.
  *
  * @param {string} username
  * @param {string} source - SUPPORTED_SOURCES のいずれか ('github' | 'hatena' | 'rss')

--- a/src/server.js
+++ b/src/server.js
@@ -33,7 +33,7 @@ const USER_PATTERN_GH_LIKE = /^[A-Za-z0-9_-]{1,39}$/;
 // never round-trips to an external API — so we accept any reasonable
 // printable string (letters / digits / punctuation / spaces, ≤64 chars).
 // XSS is already prevented by the JSON-encoded + `<` escaped injection in
-// renderEmbed() / webp-generator.js.
+// renderViewer() / webp-generator.js.
 const USER_PATTERN_LABEL = /^[\p{L}\p{N}\p{P}\s_-]{1,64}$/u;
 // `feed` is a fully qualified http/https URL. The 1024-char cap is tighter
 // than RFC's de-facto 2048: Cloudflare and most CDNs reject URLs longer
@@ -97,11 +97,13 @@ function parseSharedParams(c) {
 }
 
 // Eager load template at module init. Failing fast at startup is preferable
-// to lazily failing on the first request.
-const EMBED_TEMPLATE = readFileSync(join(__dirname, 'renderer', 'embed.html'), 'utf-8');
+// to lazily failing on the first request. The on-disk filename
+// `embed.html` is kept for git history continuity; the template is served
+// at the public route `/viewer`.
+const VIEWER_TEMPLATE = readFileSync(join(__dirname, 'renderer', 'embed.html'), 'utf-8');
 
 /**
- * Render the embed template by replacing __USER__ / __SOURCE__ / __THEME__ /
+ * Render the viewer template by replacing __USER__ / __SOURCE__ / __THEME__ /
  * __SIZE__ / __VIEW__ placeholders (script context, JSON-encoded) and
  * __PALETTE_*__ placeholders (CSS context, raw hex strings) in a single pass.
  *
@@ -117,14 +119,14 @@ const EMBED_TEMPLATE = readFileSync(join(__dirname, 'renderer', 'embed.html'), '
  * as `?user=zzz__VIEW__zzz` cannot accidentally inject into a later
  * placeholder slot the way chained `.replace()` calls allowed.
  */
-function renderEmbed(params) {
+function renderViewer(params) {
   const scriptMap = {
     USER: params.user,
     SOURCE: params.source,
     THEME: params.theme,
     SIZE: params.size,
     VIEW: params.view,
-    // null when source != rss so the embed JS can skip appending &feed=.
+    // null when source != rss so the viewer JS can skip appending &feed=.
     FEED: params.feed ?? null
   };
   const cssMap = {
@@ -134,7 +136,7 @@ function renderEmbed(params) {
     PALETTE_ACCENT: params.palette.accent,
     PALETTE_HIGHLIGHT: params.palette.highlight
   };
-  return EMBED_TEMPLATE.replace(
+  return VIEWER_TEMPLATE.replace(
     /__(USER|SOURCE|THEME|SIZE|VIEW|FEED|PALETTE_BG|PALETTE_INK|PALETTE_GRID|PALETTE_ACCENT|PALETTE_HIGHLIGHT)__/g,
     (_, k) => {
       if (k in cssMap) return cssMap[k];
@@ -151,27 +153,27 @@ app.get('/health', (c) => {
 });
 
 /**
- * /embed — canonical renderer (HTML for iframe usage).
- * /api/graph is a WebP export over this same renderer with view=auto.
+ * /viewer — canonical renderer (HTML for iframe usage).
+ * /image is a WebP export over this same renderer with view=auto.
  */
-app.get('/embed', (c) => {
+app.get('/viewer', (c) => {
   const params = parseSharedParams(c);
   if (params.error) {
     return c.json({ error: params.error }, 400);
   }
 
-  const html = renderEmbed(params);
+  const html = renderViewer(params);
 
   c.header('Cache-Control', 'public, max-age=3600');
   return c.html(html);
 });
 
 /**
- * /api/graph — WebP export of /embed.
+ * /image — WebP export of /viewer.
  * - view=auto (default): animated playback of all views
  * - view=kira|month|week: single-view static export
  */
-app.get('/api/graph', async (c) => {
+app.get('/image', async (c) => {
   const params = parseSharedParams(c);
   if (params.error) {
     return c.json({ error: params.error }, 400);
@@ -218,13 +220,13 @@ app.get('/api/graph', async (c) => {
       }
     });
   } catch (error) {
-    console.error('Error generating graph:', error);
+    console.error('Error generating image:', error);
     // For source=rss we deliberately return a generic message so a malformed
     // / malicious URL or upstream HTTP error doesn't echo back details that
     // help probe internal infrastructure. github / hatena keep the original
     // surface since their failure modes are well-known public APIs.
     const details = source === 'rss' ? 'feed fetch failed' : error.message;
-    return c.json({ error: 'Failed to generate graph', details }, 500);
+    return c.json({ error: 'Failed to generate image', details }, 500);
   }
 });
 
@@ -282,17 +284,17 @@ app.get('/', (c) => {
         <option value="month">month (calendar)</option>
         <option value="week">week (line)</option>
       </select>
-      <button onclick="showEmbed()">Show /embed</button>
-      <button onclick="showGraph()">Export /api/graph</button>
+      <button onclick="showViewer()">Show /viewer</button>
+      <button onclick="showImage()">Export /image</button>
     </div>
 
     <div class="result" id="result"></div>
 
     <div class="example">
       <h3>Endpoints</h3>
-      <p><code>/embed?user=USER&view=auto</code> - canonical iframe renderer</p>
-      <p><code>/api/graph?user=USER</code> - WebP export (view=auto by default)</p>
-      <p><code>/api/graph?user=USER&view=kira</code> - single-view static WebP</p>
+      <p><code>/viewer?user=USER&view=auto</code> - canonical iframe renderer</p>
+      <p><code>/image?user=USER</code> - WebP export (view=auto by default)</p>
+      <p><code>/image?user=USER&view=kira</code> - single-view static WebP</p>
 
       <h3>Shared parameters</h3>
       <p><code>user</code> required</p>
@@ -304,21 +306,21 @@ app.get('/', (c) => {
   </div>
 
   <script>
-    function showEmbed() {
+    function showViewer() {
       const username = document.getElementById('username').value;
       const view = document.getElementById('view').value;
       if (!username) { alert('Enter a username'); return; }
       const result = document.getElementById('result');
-      result.innerHTML = '<iframe src="/embed?user=' + encodeURIComponent(username) + '&view=' + view + '"></iframe>';
+      result.innerHTML = '<iframe src="/viewer?user=' + encodeURIComponent(username) + '&view=' + view + '"></iframe>';
     }
-    function showGraph() {
+    function showImage() {
       const username = document.getElementById('username').value;
       const view = document.getElementById('view').value;
       if (!username) { alert('Enter a username'); return; }
       const result = document.getElementById('result');
       result.innerHTML = '<p>Generating...</p>';
       const img = new Image();
-      img.src = '/api/graph?user=' + encodeURIComponent(username) + '&view=' + view;
+      img.src = '/image?user=' + encodeURIComponent(username) + '&view=' + view;
       img.onload = () => { result.innerHTML = ''; result.appendChild(img); };
       img.onerror = () => { result.innerHTML = '<p style="color:#f00;">Failed</p>'; };
     }

--- a/src/server.js
+++ b/src/server.js
@@ -195,8 +195,8 @@ app.get('/image', async (c) => {
     // multiple labels share one cached fetch and prevents trivial cache
     // pollution by varying `user` against the same feed.
     const cacheKey = source === 'rss'
-      ? `graph_rss_${theme}_${size}_${view}${feedKey}`
-      : `graph_${source}_${user}_${theme}_${size}_${view}`;
+      ? `image_rss_${theme}_${size}_${view}${feedKey}`
+      : `image_${source}_${user}_${theme}_${size}_${view}`;
     const cached = cache.get(cacheKey);
     if (cached) {
       return new Response(cached, {

--- a/src/services/registry.js
+++ b/src/services/registry.js
@@ -85,7 +85,7 @@ export function getProvider(source) {
 
 /**
  * In-flight deduplication: when multiple concurrent requests target the same
- * (source, user, feed) tuple — typically the embed pre-warming kira/month/week
+ * (source, user, feed) tuple — typically the viewer pre-warming kira/month/week
  * in parallel — we collapse them onto a single upstream fetch. Each entry is
  * removed in `finally` so that errors do not poison the cache.
  */


### PR DESCRIPTION
## 関連 Issue
closes #9

## 変更内容

### 公開エンドポイントのリネーム

| 旧 | 新 | 用途 |
|---|---|---|
| `/api/graph` | `/image` | WebP 出力（animated / single-view を `view` パラメータで分岐） |
| `/embed` | `/viewer` | iframe 用 HTML |
| `/health` | `/health` | そのまま |
| `/` | `/` | デモページ、そのまま |

- **`/snapshot` は作らない**: `/image?view=kira|month|week` で単一ビュー出力が既にできるため、エンドポイントを増やさない
- **後方互換性なし**: 旧ルート (`/api/graph`, `/embed`) は削除（kako-jun 方針: Old names are removed）
- 旧ルートは 404 を返す

### 内部リネーム
- `embed.html` 内の `graphUrl(view)` → `imageUrl(view)`
- ファイル名 `embed.html` は **維持**（git history を壊さない）

### ドキュメント
- README / CLAUDE.md / PERFORMANCE.md / docs/visual-direction.md の全 `/api/graph` と `/embed` を新名称に置換

## Acceptance criteria

- [x] Public routes が plain で広く理解可能な名前
- [x] Image output が `/image` 中心
- [x] Interactive browser/iframe ルートに自然な公開名 (`/viewer`)
- [x] 旧名は削除済み

## 動作確認

```
/viewer?user=foo                  → 200
/image?user=foo&view=kira         → 500 (data fetch fail、ルーティング OK)
/embed?user=foo                   → 404 (削除済み)
/api/graph?user=foo               → 404 (削除済み)
viewer HTML 内で imageUrl(...) が /image を生成
```